### PR TITLE
Handle missing SEO context and wire job salary overrides

### DIFF
--- a/src/components/seo/SeoContext.jsx
+++ b/src/components/seo/SeoContext.jsx
@@ -1,14 +1,31 @@
 import React, { createContext, useContext } from 'react';
 
+const loggedWarnings = new Set();
+
+const warnMissingProvider = (methodName = 'useSeo') => {
+  if (loggedWarnings.has(methodName)) {
+    return;
+  }
+
+  loggedWarnings.add(methodName);
+
+  if (typeof console !== 'undefined' && typeof console.warn === 'function') {
+    console.warn(
+      `[SeoContext] ${methodName} called before <SeoProvider> was initialised. Returning safe no-op defaults.`,
+    );
+  }
+};
+
 const defaultContextValue = {
   seo: {},
   defaults: {},
   overrides: {},
-  setSeo: () => {
-    throw new Error('setSeo called outside of SeoProvider');
+  setSeo: (...args) => {
+    warnMissingProvider('setSeo');
+    return args?.[0];
   },
   resetSeo: () => {
-    throw new Error('resetSeo called outside of SeoProvider');
+    warnMissingProvider('resetSeo');
   },
 };
 
@@ -20,9 +37,12 @@ export function SeoProvider({ value, children }) {
 
 export function useSeo() {
   const context = useContext(SeoContext);
+
   if (!context || context === defaultContextValue) {
-    throw new Error('useSeo must be used within a SeoProvider');
+    warnMissingProvider('useSeo');
+    return defaultContextValue;
   }
+
   return context;
 }
 

--- a/src/pages/JobSalaryPage.jsx
+++ b/src/pages/JobSalaryPage.jsx
@@ -1,7 +1,7 @@
 // --- ALL IMPORTS MUST BE AT THE TOP ---
 import React, { useEffect, useMemo } from 'react';
 import { useParams, useLocation, useNavigate, Link } from 'react-router-dom';
-import { Helmet } from 'react-helmet-async';
+import { useSeo } from '@/components/seo/SeoContext';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { jobTitles, createSlug } from '../components/data/seo-data';
@@ -35,7 +35,10 @@ export default function JobSalaryPage() {
   }, [slug, selectedRole, navigate]);
 
   // If we just redirected (no slug yet), render nothing
-  if (!slug || !selectedRole) return null;
+  if (!slug || !selectedRole) {
+    resetSeo();
+    return null;
+  }
 
   const origin =
     typeof window !== 'undefined' ? window.location.origin : 'https://www.calcmymoney.co.uk';
@@ -103,13 +106,28 @@ export default function JobSalaryPage() {
       : null,
   ].filter(Boolean);
 
+  useEffect(() => {
+    const seoPayload = {
+      title: pageTitle,
+      description: pageDesc,
+      canonical,
+      robots: 'index,follow,max-image-preview:large',
+      ogTitle: pageTitle,
+      ogDescription: pageDesc,
+      ogUrl: canonical,
+      twitterTitle: pageTitle,
+      twitterDescription: pageDesc,
+    };
+
+    setSeo(seoPayload);
+
+    return () => {
+      resetSeo();
+    };
+  }, [canonical, pageDesc, pageTitle, resetSeo, setSeo]);
+
   return (
     <div className="bg-white dark:bg-gray-900">
-      <Helmet>
-        <title>{pageTitle}</title>
-        <meta name="description" content={pageDesc} />
-        <link rel="canonical" href={canonical} />
-      </Helmet>
       <div className="max-w-5xl mx-auto px-4 py-8 space-y-8">
         <div className="flex flex-col gap-4">
           <Link className="text-blue-600 hover:text-blue-700 font-medium" to="/job-salaries">


### PR DESCRIPTION
## Summary
- make the SEO context hook return safe fallbacks when the provider is missing
- connect the job salary detail page to the shared SEO overrides instead of using a local Helmet instance

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e007a82cfc832097a804aad72b4916