### PR TITLE
Update hero styling across informational pages

### DIFF
--- a/src/pages/About.jsx
+++ b/src/pages/About.jsx
@@ -18,12 +18,12 @@ export default function About() {
     <>
       <script type="application/ld+json">{JSON.stringify(breadcrumbJson)}</script>
       <div className="bg-background">
-        <div className="bg-hero border-b border-border/60">
+        <div className="bg-hero bg-hero-pattern text-hero-foreground border-b border-border/60">
           <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-12 text-center">
-            <Heading as="h1" size="h1" weight="bold" underline className="text-hero-foreground">
+            <Heading as="h1" size="h1" weight="bold" underline>
               About Calculate My Money
             </Heading>
-            <p className="lead text-muted-foreground max-w-3xl mx-auto mt-3">
+            <p className="lead text-hero-foreground/80 max-w-3xl mx-auto mt-3">
               Who we are and how we build accurate, transparent UK financial calculators.
             </p>
           </div>

--- a/src/pages/Blog.jsx
+++ b/src/pages/Blog.jsx
@@ -75,18 +75,20 @@ const categoryColors = {
 
 export default function Blog() {
   return (
-    <div className="bg-neutral-soft py-12">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="text-center mb-16">
-          <Heading as="h1" size="h1" weight="bold" underline className="mb-6 text-foreground">
+    <div className="bg-background">
+      <div className="bg-hero bg-hero-pattern text-hero-foreground">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12 text-center">
+          <Heading as="h1" size="h1" weight="bold" underline className="mb-6">
             Financial Insights &amp; Updates
           </Heading>
-          <p className="lead text-muted-foreground max-w-3xl mx-auto">
+          <p className="lead text-hero-foreground/80 max-w-3xl mx-auto">
             Stay informed with the latest UK financial news, tax updates, and money management
             strategies.
           </p>
         </div>
+      </div>
 
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
         <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-8">
           {blogPosts.map((post, index) => (
             <Link
@@ -111,7 +113,7 @@ export default function Blog() {
                 <CardHeader>
                   <div className="mb-2 flex items-center justify-between text-sm text-muted-foreground">
                     <span
-                      className={`px-2 py-1 rounded text-xs font-medium ${categoryColors[post.category] || 'bg-gray-100 text-gray-800'}`}
+                      className={`px-2 py-1 rounded text-xs font-medium ${categoryColors[post.category] || 'bg-muted text-foreground'}`}
                     >
                       {post.category}
                     </span>

--- a/src/pages/BlogSmartMoneySavingTips.jsx
+++ b/src/pages/BlogSmartMoneySavingTips.jsx
@@ -127,40 +127,44 @@ export default function BlogSmartMoneySavingTips() {
   }, [articleJsonLd, defaults?.jsonLd, post, resetSeo, setSeo]);
 
   return (
-    <div className="bg-background py-12">
-      <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
-        <Link
-          to={createPageUrl('Blog')}
-          className="mb-8 inline-flex items-center text-primary hover:underline"
-        >
-          <ArrowLeft className="w-4 h-4 mr-2" />
-          Back to all articles
-        </Link>
+    <div className="bg-background">
+      <article>
+        <div className="bg-hero bg-hero-pattern text-hero-foreground">
+          <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+            <Link
+              to={createPageUrl('Blog')}
+              className="mb-6 inline-flex items-center text-hero-foreground hover:text-hero-foreground/80"
+            >
+              <ArrowLeft className="w-4 h-4 mr-2" />
+              Back to all articles
+            </Link>
 
-        <article>
-          <header className="mb-8">
-            <span className="bg-pill text-pill-foreground px-3 py-1 rounded-full text-sm font-medium">
-              {post.category}
-            </span>
-            <Heading as="h1" size="h1" weight="bold" className="mt-4 mb-4 text-foreground">
-              {post.title}
-            </Heading>
-            <div className="flex flex-wrap items-center gap-x-6 gap-y-2 text-sm text-muted-foreground">
-              <div className="flex items-center gap-2">
-                <User className="w-4 h-4" />
-                <span>{post.author}</span>
+            <header className="mb-8">
+              <span className="bg-pill text-pill-foreground px-3 py-1 rounded-full text-sm font-medium">
+                {post.category}
+              </span>
+              <Heading as="h1" size="h1" weight="bold" className="mt-4 mb-4">
+                {post.title}
+              </Heading>
+              <div className="flex flex-wrap items-center gap-x-6 gap-y-2 text-sm text-hero-foreground/80">
+                <div className="flex items-center gap-2">
+                  <User className="w-4 h-4" />
+                  <span>{post.author}</span>
+                </div>
+                <div className="flex items-center gap-2">
+                  <Calendar className="w-4 h-4" />
+                  <time dateTime={post.publishedTime}>{post.displayDate}</time>
+                </div>
+                <div className="flex items-center gap-2">
+                  <Clock className="w-4 h-4" />
+                  <span>{post.readTime}</span>
+                </div>
               </div>
-              <div className="flex items-center gap-2">
-                <Calendar className="w-4 h-4" />
-                <time dateTime={post.publishedTime}>{post.displayDate}</time>
-              </div>
-              <div className="flex items-center gap-2">
-                <Clock className="w-4 h-4" />
-                <span>{post.readTime}</span>
-              </div>
-            </div>
-          </header>
+            </header>
+          </div>
+        </div>
 
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
           <img
             src={createUnsplashUrl(heroImage.baseUrl, heroImage.params, heroImage.width)}
             srcSet={createUnsplashSrcSet(heroImage.baseUrl, heroImage.params, heroImage.srcSetWidths)}
@@ -183,7 +187,9 @@ export default function BlogSmartMoneySavingTips() {
 
             <Separator className="my-8" />
 
-            <h2 className="heading-2">Winning the Grocery Game: Strategies for the Supermarket</h2>
+            <Heading as="h2" size="h2" className="mt-12">
+              Winning the Grocery Game: Strategies for the Supermarket
+            </Heading>
             <p>
               Groceries are often one of the largest flexible expenses for families. Small changes
               here can lead to significant savings.
@@ -236,7 +242,9 @@ export default function BlogSmartMoneySavingTips() {
               </p>
             </div>
 
-            <h2 className="heading-2">Taming the Energy Beast: Heating, Lighting &amp; Appliances</h2>
+            <Heading as="h2" size="h2" className="mt-12">
+              Taming the Energy Beast: Heating, Lighting &amp; Appliances
+            </Heading>
             <p>With fluctuating energy prices, making your home more energy-efficient is key.</p>
             <ul>
               <li>
@@ -284,7 +292,9 @@ export default function BlogSmartMoneySavingTips() {
               </p>
             </div>
 
-            <h2 className="heading-2">Quick Wins: Small Changes, Big Impact</h2>
+            <Heading as="h2" size="h2" className="mt-12">
+              Quick Wins: Small Changes, Big Impact
+            </Heading>
             <p>Sometimes the smallest adjustments yield the greatest results:</p>
             <ul>
               <li>
@@ -307,7 +317,9 @@ export default function BlogSmartMoneySavingTips() {
 
             <Separator className="my-8" />
 
-            <h2 className="heading-2">Making it Sustainable: The Long Game</h2>
+            <Heading as="h2" size="h2" className="mt-12">
+              Making it Sustainable: The Long Game
+            </Heading>
             <p>
               The key to lasting financial change isn't dramatic overnight transformations – it's
               building sustainable habits that compound over time. Start with one or two changes

--- a/src/pages/JobSalaries.jsx
+++ b/src/pages/JobSalaries.jsx
@@ -3,8 +3,9 @@ import { Link } from 'react-router-dom';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Badge } from '@/components/ui/badge';
+import Heading from '@/components/common/Heading';
 import { jobTitles, createSlug } from '../components/data/seo-data';
-import { Briefcase, Search, PoundSterling } from 'lucide-react';
+import { Briefcase, Search } from 'lucide-react';
 
 export default function JobSalaries() {
   const [searchTerm, setSearchTerm] = useState('');
@@ -16,25 +17,23 @@ export default function JobSalaries() {
   );
 
   return (
-    <div className="bg-white dark:bg-gray-900">
-      <div className="bg-gray-50 dark:bg-gray-800/50 border-b border-gray-200 dark:border-gray-700">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
-          <div className="text-center">
-            <h1 className="text-3xl md:text-4xl font-bold text-gray-900 dark:text-gray-100 mb-4">
-              UK Job Salary Explorer
-            </h1>
-            <p className="text-lg text-gray-600 dark:text-gray-300 max-w-3xl mx-auto">
-              Discover average salaries for hundreds of jobs across the UK. Find out what you could
-              be earning.
-            </p>
-          </div>
+    <div className="bg-background text-foreground">
+      <div className="bg-hero bg-hero-pattern text-hero-foreground">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12 text-center">
+          <Heading as="h1" size="h1" weight="bold" className="mb-4">
+            UK Job Salary Explorer
+          </Heading>
+          <p className="lead text-hero-foreground/80 max-w-3xl mx-auto">
+            Discover average salaries for hundreds of jobs across the UK. Find out what you could be
+            earning.
+          </p>
         </div>
       </div>
 
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         <div className="mb-8">
           <div className="relative">
-            <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 w-5 h-5 text-gray-400" />
+            <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 w-5 h-5 text-muted-foreground" />
             <Input
               type="text"
               placeholder="Search for a job title..."
@@ -54,15 +53,15 @@ export default function JobSalaries() {
                   key={job.title}
                   className="group"
                 >
-                  <Card className="hover:shadow-lg hover:border-blue-300 transition-all">
+                  <Card className="hover:shadow-lg hover:border-primary/60 transition-all">
                     <CardHeader>
                       <CardTitle className="flex items-center gap-2">
-                        <Briefcase className="w-5 h-5 text-blue-600" />
+                        <Briefcase className="w-5 h-5 text-primary" />
                         <span>{job.title}</span>
                       </CardTitle>
                     </CardHeader>
                     <CardContent>
-                      <p className="text-sm text-gray-600 mb-2">{job.description}</p>
+                      <p className="text-sm text-muted-foreground mb-2">{job.description}</p>
                       <div className="flex items-center justify-between">
                         <Badge variant="secondary">{job.category}</Badge>
                         <span className="font-semibold text-lg">
@@ -74,7 +73,7 @@ export default function JobSalaries() {
                 </Link>
               ))
             ) : (
-              <p className="text-center md:col-span-3 text-gray-500">
+              <p className="text-center md:col-span-3 text-muted-foreground">
                 No job titles found for "{searchTerm}".
               </p>
             )}
@@ -82,9 +81,9 @@ export default function JobSalaries() {
         ) : (
           categories.map((category) => (
             <div key={category} className="mb-10">
-              <h2 className="text-2xl font-bold border-b-2 border-blue-500 pb-2 mb-4">
+              <Heading as="h2" size="h2" weight="bold" className="mb-4 border-b-2 border-primary pb-2">
                 {category}
-              </h2>
+              </Heading>
               <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-4">
                 {jobTitles
                   .filter((job) => job.category === category)
@@ -94,11 +93,11 @@ export default function JobSalaries() {
                       key={job.title}
                       className="group"
                     >
-                      <div className="p-4 bg-gray-50 rounded-lg hover:bg-blue-100 transition-colors">
-                        <p className="font-semibold text-gray-800 group-hover:text-blue-700">
+                      <div className="p-4 rounded-lg border border-card-muted bg-card transition-colors hover:border-primary/40">
+                        <p className="font-semibold text-card-foreground group-hover:text-primary">
                           {job.title}
                         </p>
-                        <p className="text-sm text-gray-600">
+                        <p className="text-sm text-muted-foreground">
                           ~£{job.averageSalary.toLocaleString()}
                         </p>
                       </div>

--- a/src/pages/SalaryCalculatorUK.jsx
+++ b/src/pages/SalaryCalculatorUK.jsx
@@ -908,14 +908,14 @@ export default function SalaryCalculatorUK() {
 
       <div className="bg-background">
         {/* Page Header - Optimized for SEO */}
-        <div className="bg-hero border-b border-border/60 non-printable">
+        <div className="bg-hero bg-hero-pattern text-hero-foreground border-b border-border/60 non-printable">
           <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
             <Breadcrumbs path={breadcrumbPath} />
             <div className="text-center">
-              <Heading as="h1" size="h1" weight="bold" className="mb-4 text-hero-foreground">
+              <Heading as="h1" size="h1" weight="bold" className="mb-4">
                 UK Salary Calculator – Take-Home Pay 2025/26
               </Heading>
-              <p className="lead text-muted-foreground max-w-3xl mx-auto">
+              <p className="lead text-hero-foreground/80 max-w-3xl mx-auto">
                 Calculate your UK take-home pay for the 2025/26 tax year. Free salary calculator
                 with accurate income tax, National Insurance, and pension contributions. Works for
                 England, Wales, Scotland & Northern Ireland.
@@ -925,32 +925,32 @@ export default function SalaryCalculatorUK() {
               <div className="mt-6 flex flex-wrap justify-center gap-2">
                 <Link
                   to={createPageUrl('SalaryCalculatorTakeHomePay')}
-                  className="px-4 py-2 rounded-md border border-blue-200 text-blue-700 bg-white hover:bg-blue-50 dark:bg-gray-800 dark:text-blue-300 dark:border-blue-700"
+                  className="px-4 py-2 rounded-md border border-hero-ring/60 bg-hero-foreground/10 text-hero-foreground transition-colors hover:bg-hero-foreground/20"
                 >
                   Take‑Home Pay
                 </Link>
                 <Link
                   to={createPageUrl('SalaryCalculatorPaycheck')}
-                  className="px-4 py-2 rounded-md border border-blue-200 text-blue-700 bg-white hover:bg-blue-50 dark:bg-gray-800 dark:text-blue-300 dark:border-blue-700"
+                  className="px-4 py-2 rounded-md border border-hero-ring/60 bg-hero-foreground/10 text-hero-foreground transition-colors hover:bg-hero-foreground/20"
                 >
                   Paycheck
                 </Link>
                 <Link
                   to={createPageUrl('GrossToNetCalculator')}
-                  className="px-4 py-2 rounded-md border border-blue-200 text-blue-700 bg-white hover:bg-blue-50 dark:bg-gray-800 dark:text-blue-300 dark:border-blue-700"
+                  className="px-4 py-2 rounded-md border border-hero-ring/60 bg-hero-foreground/10 text-hero-foreground transition-colors hover:bg-hero-foreground/20"
                 >
                   Gross‑to‑Net
                 </Link>
                 <Link
                   to={createPageUrl('ProRataSalaryCalculator')}
-                  className="px-4 py-2 rounded-md border border-blue-200 text-blue-700 bg-white hover:bg-blue-50 dark:bg-gray-800 dark:text-blue-300 dark:border-blue-700"
+                  className="px-4 py-2 rounded-md border border-hero-ring/60 bg-hero-foreground/10 text-hero-foreground transition-colors hover:bg-hero-foreground/20"
                 >
                   Pro‑Rata
                 </Link>
               </div>
 
               {/* Additional keyword-rich content */}
-              <div className="mt-6 text-sm text-muted-foreground max-w-4xl mx-auto">
+              <div className="mt-6 text-sm text-hero-foreground/80 max-w-4xl mx-auto">
                 <p>
                   Supports gross-to-net and net-to-gross calculations • Updated for 2025/26 tax
                   rates • Includes student loan repayments • Scottish income tax rates supported
@@ -1855,7 +1855,7 @@ export default function SalaryCalculatorUK() {
         </div>
 
         {/* Visible FAQ section aligned with JSON-LD */}
-        <div className="bg-neutral-soft py-12 non-printable">
+        <div className="bg-muted py-12 non-printable">
           <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
             <FAQSection faqs={salaryHubFaqs} title="Salary Calculator FAQs" />
             <p className="text-xs text-muted-foreground mt-6">
@@ -1865,14 +1865,14 @@ export default function SalaryCalculatorUK() {
         </div>
 
         {/* Replace the second FAQ section to keep alignment */}
-        <div id="faq-section" className="bg-neutral-soft py-12 non-printable">
+        <div id="faq-section" className="bg-muted py-12 non-printable">
           <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
             <FAQSection faqs={salaryHubFaqs} />
           </div>
         </div>
 
         {/* Additional content section for keywords */}
-        <div className="bg-neutral-soft py-12 non-printable">
+        <div className="bg-muted py-12 non-printable">
           <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
             <div className="text-center mb-8">
               <Heading as="h2" size="h2" weight="bold" className="mb-4 text-foreground">

--- a/src/pages/UKFinancialStats.jsx
+++ b/src/pages/UKFinancialStats.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { TrendingUp, TrendingDown, Percent, Home, Landmark, Zap, ExternalLink } from 'lucide-react';
+import Heading from '@/components/common/Heading';
 
 const StatCard = ({ title, value, change, description, trend, link, Icon }) => {
   const TrendIcon = trend === 'up' ? TrendingUp : trend === 'down' ? TrendingDown : null;
@@ -10,18 +11,18 @@ const StatCard = ({ title, value, change, description, trend, link, Icon }) => {
     <Card className="h-full flex flex-col">
       <CardHeader className="flex flex-row items-center justify-between pb-2">
         <CardTitle className="text-base font-medium">{title}</CardTitle>
-        <Icon className="w-5 h-5 text-gray-500" />
+        <Icon className="w-5 h-5 text-muted-foreground" />
       </CardHeader>
       <CardContent className="flex-grow flex flex-col justify-center">
         <div className="text-3xl font-bold">{value}</div>
         {change && (
-          <div className="text-sm text-gray-600 flex items-center gap-1">
+          <div className="text-sm text-muted-foreground flex items-center gap-1">
             {TrendIcon && <TrendIcon className={`w-4 h-4 ${trendColor}`} />}
             <span className={trendColor}>{change}</span>
             <span>vs last year</span>
           </div>
         )}
-        <p className="text-xs text-gray-500 mt-2">{description}</p>
+        <p className="text-xs text-muted-foreground mt-2">{description}</p>
       </CardContent>
       {link && (
         <div className="p-4 pt-0 text-xs">
@@ -29,7 +30,7 @@ const StatCard = ({ title, value, change, description, trend, link, Icon }) => {
             href={link}
             target="_blank"
             rel="noopener noreferrer"
-            className="flex items-center gap-1 text-blue-600 hover:underline"
+            className="flex items-center gap-1 text-primary hover:underline"
           >
             Source <ExternalLink className="w-3 h-3" />
           </a>
@@ -44,18 +45,16 @@ export default function UKFinancialStats() {
   // Users are directed to the official sources for the most up-to-date information.
 
   return (
-    <div className="bg-white dark:bg-gray-900">
-      <div className="bg-gray-50 dark:bg-gray-800/50 border-b border-gray-200 dark:border-gray-700">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
-          <div className="text-center">
-            <h1 className="text-3xl md:text-4xl font-bold text-gray-900 dark:text-gray-100 mb-4">
-              UK Financial Statistics Dashboard
-            </h1>
-            <p className="text-lg text-gray-600 dark:text-gray-300 max-w-3xl mx-auto">
-              Track key UK economic indicators. Data is sourced directly from official channels like
-              the Bank of England and the Office for National Statistics.
-            </p>
-          </div>
+    <div className="bg-background text-foreground">
+      <div className="bg-hero bg-hero-pattern text-hero-foreground">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12 text-center">
+          <Heading as="h1" size="h1" weight="bold" className="mb-4">
+            UK Financial Statistics Dashboard
+          </Heading>
+          <p className="lead text-hero-foreground/80 max-w-3xl mx-auto">
+            Track key UK economic indicators. Data is sourced directly from official channels like
+            the Bank of England and the Office for National Statistics.
+          </p>
         </div>
       </div>
 
@@ -94,7 +93,7 @@ export default function UKFinancialStats() {
             link="https://www.ofgem.gov.uk/energy-price-cap"
           />
         </div>
-        <div className="mt-12 text-center text-sm text-gray-500">
+        <div className="mt-12 text-center text-sm text-muted-foreground">
           <p>
             Disclaimer: Data shown here is for informational purposes only. Please consult the
             official sources linked in each card for the most current and accurate figures before


### PR DESCRIPTION
## Summary
- align the blog listing, blog detail, statistics, salary calculator, and about pages with the shared hero gradient styling and text palette
- replace hard-coded gray backgrounds with design tokens and reuse the shared Heading component for section titles
- adjust supporting UI accents so contrast remains accessible after the gradient update

## Testing
- npm run lint *(fails: missing dependency `@eslint/js` in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e11bdb60dc8320bab160bbd74207d0