### PR TITLE
Adjust mid-level heading clamp sizes

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -171,7 +171,7 @@
     letter-spacing: -0.01em;
     line-height: 1.2;
     color: hsl(var(--foreground));
-    font-size: clamp(1.65rem, 1.45rem + 0.7vw, 2.2rem);
+    font-size: clamp(1.4rem, 1.25rem + 0.6vw, 1.8rem);
   }
 
   h4,
@@ -181,7 +181,7 @@
     letter-spacing: -0.005em;
     line-height: 1.3;
     color: hsl(var(--foreground));
-    font-size: clamp(1.35rem, 1.25rem + 0.35vw, 1.7rem);
+    font-size: clamp(1.25rem, 1.15rem + 0.35vw, 1.6rem);
   }
 
   p.lead,


### PR DESCRIPTION
## Summary
- lower the responsive clamp ranges for heading-3 and heading-4 to better suit cards and section headers

## Testing
- ENABLE_CRITICAL=0 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e143a7c9748320acb68d3914838bb4