### PR TITLE
Replace text-[0.8rem] utility with caption styles

### DIFF
--- a/src/components/ui/calendar.jsx
+++ b/src/components/ui/calendar.jsx
@@ -24,7 +24,7 @@ function Calendar({ className, classNames, showOutsideDays = true, ...props }) {
         nav_button_next: 'absolute right-1',
         table: 'w-full border-collapse space-y-1',
         head_row: 'flex',
-        head_cell: 'text-muted-foreground rounded-md w-8 font-normal text-[0.8rem]',
+        head_cell: 'text-muted-foreground rounded-md w-8 font-normal caption',
         row: 'flex w-full mt-2',
         cell: cn(
           'relative p-0 text-center text-sm focus-within:relative focus-within:z-20 [&:has([aria-selected])]:bg-accent [&:has([aria-selected].day-outside)]:bg-accent/50 [&:has([aria-selected].day-range-end)]:rounded-r-md',

--- a/src/components/ui/form.jsx
+++ b/src/components/ui/form.jsx
@@ -90,7 +90,7 @@ const FormDescription = React.forwardRef(({ className, ...props }, ref) => {
     <p
       ref={ref}
       id={formDescriptionId}
-      className={cn('text-[0.8rem] text-muted-foreground', className)}
+      className={cn('caption text-muted-foreground', className)}
       {...props}
     />
   );
@@ -109,7 +109,7 @@ const FormMessage = React.forwardRef(({ className, children, ...props }, ref) =>
     <p
       ref={ref}
       id={formMessageId}
-      className={cn('text-[0.8rem] font-medium text-destructive', className)}
+      className={cn('caption font-medium text-destructive', className)}
       {...props}
     >
       {body}


### PR DESCRIPTION
## Summary
- switch form description and message helpers to use the caption text style utility
- align the calendar header cell typography with the caption class
- verify that no other text-[0.8rem] utilities remain in the project

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e14fe1f5648320ab42ad414a357d6d