### PR TITLE
Add Money Blueprint schema validation and guidance

### DIFF
--- a/src/components/wizard/StepGuidance.jsx
+++ b/src/components/wizard/StepGuidance.jsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { Lightbulb } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+
+export default function StepGuidance({ title, points = [], icon: Icon = Lightbulb, className }) {
+  if (!title && (!points || points.length === 0)) {
+    return null;
+  }
+
+  return (
+    <div
+      className={cn(
+        'rounded-2xl border border-primary/30 bg-primary/5 p-4 text-sm text-primary-foreground dark:border-primary/40 dark:bg-primary/10',
+        className
+      )}
+    >
+      <div className="flex items-start gap-3">
+        <span className="mt-0.5 flex h-8 w-8 items-center justify-center rounded-full bg-primary/15 text-primary">
+          <Icon className="h-4 w-4" />
+        </span>
+        <div className="space-y-2">
+          {title ? <p className="font-semibold text-foreground">{title}</p> : null}
+          {Array.isArray(points) && points.length > 0 ? (
+            <ul className="space-y-1 text-muted-foreground">
+              {points.map((point, index) => (
+                <li key={index} className="flex items-start gap-2">
+                  <span aria-hidden className="mt-1.5 h-1.5 w-1.5 flex-shrink-0 rounded-full bg-primary" />
+                  <span>{point}</span>
+                </li>
+              ))}
+            </ul>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/wizard/index.js
+++ b/src/components/wizard/index.js
@@ -1,2 +1,3 @@
 export { WizardStepper } from './WizardStepper.jsx';
 export { WizardNavigation } from './WizardNavigation.jsx';
+export { default as StepGuidance } from './StepGuidance.jsx';

--- a/src/lib/moneyBlueprint/schema.js
+++ b/src/lib/moneyBlueprint/schema.js
@@ -1,0 +1,195 @@
+import { z } from 'zod';
+
+const numericPattern = /^(\d+)([\.,]\d{1,2})?$/;
+
+const coerceNumberString = (value) => value.replace(/,/g, '').replace(/\s+/g, '');
+
+const basicsSchema = z
+  .object({
+    planName: z
+      .string()
+      .trim()
+      .refine((value) => value.length === 0 || value.length >= 3, {
+        message: 'Give your blueprint a nickname of at least 3 characters or leave it blank.',
+      }),
+    householdSize: z
+      .string({ required_error: 'Enter how many people rely on this plan.' })
+      .trim()
+      .min(1, 'Enter how many people rely on this plan.')
+      .refine((value) => /^\d+$/.test(value), {
+        message: 'Use whole numbers when counting people.',
+      })
+      .refine((value) => Number.parseInt(value, 10) >= 1 && Number.parseInt(value, 10) <= 12, {
+        message: 'Enter a household size between 1 and 12.',
+      }),
+    netIncome: z
+      .string({ required_error: 'Enter your combined take-home pay.' })
+      .trim()
+      .min(1, 'Enter your combined take-home pay.')
+      .transform((value) => coerceNumberString(value))
+      .refine((value) => numericPattern.test(value), {
+        message: 'Use numbers only, you can include up to 2 decimal places.',
+      })
+      .refine((value) => Number.parseFloat(value) > 0, {
+        message: 'Enter an amount greater than zero.',
+      }),
+    incomeFrequency: z
+      .string({ required_error: 'Choose how often you receive this income.' })
+      .trim()
+      .min(1, 'Choose how often you receive this income.'),
+    region: z
+      .string({ required_error: 'Pick the region you live in.' })
+      .trim()
+      .min(1, 'Pick the region you live in.'),
+    focus: z
+      .string({ required_error: 'Select the money focus guiding your blueprint.' })
+      .trim()
+      .min(1, 'Select the money focus guiding your blueprint.'),
+  })
+  .strict();
+
+const prioritiesSchema = z
+  .object({
+    goalAreas: z
+      .array(z.string().trim().min(1))
+      .min(1, 'Select at least one goal area to continue.'),
+    topGoal: z
+      .string({ required_error: 'Describe your number one outcome.' })
+      .trim()
+      .min(10, 'Describe your number one outcome using at least 10 characters.'),
+    savingsTarget: z
+      .string()
+      .trim()
+      .refine((value) => value.length === 0 || numericPattern.test(coerceNumberString(value)), {
+        message: 'Use numbers only, you can include up to 2 decimal places.',
+      })
+      .refine((value) => value.length === 0 || Number.parseFloat(coerceNumberString(value)) > 0, {
+        message: 'Enter an amount greater than zero or leave this blank.',
+      }),
+    timeline: z
+      .string({ required_error: 'Choose the timeline that fits your goal.' })
+      .trim()
+      .min(1, 'Choose the timeline that fits your goal.'),
+  })
+  .strict();
+
+const habitsSchema = z
+  .object({
+    budgetingStyle: z
+      .string({ required_error: 'Select the budgeting style that fits best.' })
+      .trim()
+      .min(1, 'Select the budgeting style that fits best.'),
+    checkInFrequency: z
+      .string({ required_error: 'Choose how often you review your money.' })
+      .trim()
+      .min(1, 'Choose how often you review your money.'),
+    emergencyFundMonths: z
+      .string({ required_error: 'Share how many months your emergency fund covers.' })
+      .trim()
+      .min(1, 'Share how many months your emergency fund covers.'),
+    confidenceLevel: z
+      .string({ required_error: 'Tell us how confident you feel about money right now.' })
+      .trim()
+      .min(1, 'Tell us how confident you feel about money right now.'),
+    additionalNotes: z
+      .string()
+      .trim()
+      .refine((value) => value.length <= 800, {
+        message: 'Keep notes under 800 characters.',
+      }),
+  })
+  .strict();
+
+const summarySchema = z
+  .object({
+    shareEmail: z
+      .string()
+      .trim()
+      .refine(
+        (value) => value.length === 0 || /^(?:[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,})$/i.test(value),
+        {
+          message: 'Enter a valid email address or leave this blank.',
+        }
+      ),
+    consentToContact: z.boolean(),
+  })
+  .strict()
+  .superRefine((value, ctx) => {
+    if (value.consentToContact && value.shareEmail.length === 0) {
+      ctx.addIssue({
+        path: ['shareEmail'],
+        code: z.ZodIssueCode.custom,
+        message: 'Add your email so we can send the reminder.',
+      });
+    }
+  });
+
+export const moneyBlueprintStepSchemas = {
+  basics: basicsSchema,
+  priorities: prioritiesSchema,
+  habits: habitsSchema,
+  summary: summarySchema,
+};
+
+export const moneyBlueprintSchema = z.object(moneyBlueprintStepSchemas).strict();
+
+export const MONEY_BLUEPRINT_GUIDANCE = {
+  basics: {
+    title: 'Tips for the basics step',
+    points: [
+      'Include everyone who shares the same household pot, even if income fluctuates.',
+      'Use your usual net pay after tax. A rounded monthly figure is fine.',
+      'Pick the focus that best reflects what you want to change this year.',
+    ],
+  },
+  priorities: {
+    title: 'Tips for choosing priorities',
+    points: [
+      'Select the goal areas that will unlock the most progress for you.',
+      'Use the headline goal to capture the result you want to see.',
+      'Add a target amount if it helps you measure success.',
+    ],
+  },
+  habits: {
+    title: 'Tips for habits & safety nets',
+    points: [
+      'Pick the budgeting style you follow most of the time, even if it is not perfect.',
+      'Your confidence level helps us tailor the follow-up actions.',
+      'Estimate how many months of expenses your emergency fund covers.',
+    ],
+  },
+  summary: {
+    title: 'Tips before you generate your blueprint',
+    points: [
+      'Double-check the highlights in the summary card before locking in.',
+      'Share your email if you would like a reminder – we only store it with your consent.',
+      'You can revisit any step later; updating answers will refresh your share code.',
+    ],
+  },
+};
+
+export function validateMoneyBlueprintStep(stepId, stepData) {
+  const schema = moneyBlueprintStepSchemas[stepId];
+  if (!schema) {
+    return { success: true, errors: {}, issues: [] };
+  }
+
+  const result = schema.safeParse(stepData ?? {});
+  if (result.success) {
+    return { success: true, errors: {}, issues: [] };
+  }
+
+  const errors = {};
+  result.error.issues.forEach((issue) => {
+    const field = issue.path?.[0] ?? 'root';
+    if (!errors[field]) {
+      errors[field] = issue.message;
+    }
+  });
+
+  return { success: false, errors, issues: result.error.issues };
+}
+
+export function validateMoneyBlueprint(data) {
+  return moneyBlueprintSchema.safeParse(data ?? {});
+}

--- a/src/pages/MyMoneyBlueprint.jsx
+++ b/src/pages/MyMoneyBlueprint.jsx
@@ -27,11 +27,15 @@ import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Progress } from '@/components/ui/progress';
 import { useToast } from '@/components/ui/use-toast';
-import { WizardStepper, WizardNavigation } from '@/components/wizard';
+import { WizardStepper, WizardNavigation, StepGuidance } from '@/components/wizard';
 import {
   useMoneyBlueprintWizard,
   MONEY_BLUEPRINT_DEFAULT_DATA,
 } from '@/hooks/use-money-blueprint-wizard';
+import {
+  MONEY_BLUEPRINT_GUIDANCE,
+  validateMoneyBlueprintStep,
+} from '@/lib/moneyBlueprint/schema';
 import { cn } from '@/lib/utils';
 
 const regionOptions = [
@@ -191,6 +195,68 @@ export default function MyMoneyBlueprint() {
     [data?.summary]
   );
 
+  const [touchedFields, setTouchedFields] = React.useState({
+    basics: {},
+    priorities: {},
+    habits: {},
+    summary: {},
+  });
+  const [submitAttempts, setSubmitAttempts] = React.useState({
+    basics: 0,
+    priorities: 0,
+    habits: 0,
+    summary: 0,
+  });
+
+  const stepValidations = React.useMemo(
+    () => ({
+      basics: validateMoneyBlueprintStep('basics', basics),
+      priorities: validateMoneyBlueprintStep('priorities', priorities),
+      habits: validateMoneyBlueprintStep('habits', habits),
+      summary: validateMoneyBlueprintStep('summary', summary),
+    }),
+    [basics, priorities, habits, summary]
+  );
+
+  const markFieldTouched = React.useCallback((stepId, field) => {
+    if (!stepId || !field) return;
+    setTouchedFields((prev) => ({
+      ...prev,
+      [stepId]: { ...(prev?.[stepId] ?? {}), [field]: true },
+    }));
+  }, []);
+
+  const revealStepErrors = React.useCallback((stepId, fields) => {
+    if (!stepId || !Array.isArray(fields) || fields.length === 0) return;
+    setTouchedFields((prev) => {
+      const previous = prev?.[stepId] ?? {};
+      const next = { ...previous };
+      fields.forEach((field) => {
+        next[field] = true;
+      });
+      return {
+        ...prev,
+        [stepId]: next,
+      };
+    });
+  }, []);
+
+  const getFieldError = React.useCallback(
+    (stepId, field) => {
+      const validation = stepValidations[stepId];
+      if (!validation) return null;
+      const message = validation.errors?.[field];
+      if (!message) return null;
+      const touched = touchedFields?.[stepId]?.[field];
+      const attempted = (submitAttempts?.[stepId] ?? 0) > 0;
+      if (!touched && !attempted) {
+        return null;
+      }
+      return message;
+    },
+    [stepValidations, touchedFields, submitAttempts]
+  );
+
   const isComplete = status === 'completed';
   const goalsCount = priorities.goalAreas?.length || 0;
   const stepsCount = steps.length;
@@ -235,6 +301,27 @@ export default function MyMoneyBlueprint() {
   }, [reset, toast]);
 
   const handleNext = React.useCallback(() => {
+    if (!currentStep) {
+      nextStep();
+      return;
+    }
+
+    const validation = stepValidations[currentStep.id];
+    if (validation && !validation.success) {
+      const errorFields = Object.keys(validation.errors ?? {});
+      setSubmitAttempts((prev) => ({
+        ...prev,
+        [currentStep.id]: (prev?.[currentStep.id] ?? 0) + 1,
+      }));
+      revealStepErrors(currentStep.id, errorFields);
+      toast({
+        title: 'Check this step',
+        description: 'Please fix the highlighted fields before continuing.',
+        variant: 'destructive',
+      });
+      return;
+    }
+
     if (isLastStep) {
       if (isComplete) {
         toast({
@@ -252,7 +339,18 @@ export default function MyMoneyBlueprint() {
     }
 
     nextStep();
-  }, [isLastStep, isComplete, formattedReportId, completeWizard, formatReportId, nextStep, toast]);
+  }, [
+    currentStep,
+    stepValidations,
+    nextStep,
+    isLastStep,
+    isComplete,
+    formattedReportId,
+    completeWizard,
+    formatReportId,
+    revealStepErrors,
+    toast,
+  ]);
 
   const handleCopyReportId = React.useCallback(async () => {
     if (!reportId) return;
@@ -288,6 +386,7 @@ export default function MyMoneyBlueprint() {
 
   const handlePriorityToggle = React.useCallback(
     (value) => (checked) => {
+      markFieldTouched('priorities', 'goalAreas');
       updateStepData('priorities', (prev) => {
         const existing = new Set(Array.isArray(prev.goalAreas) ? prev.goalAreas : []);
         if (checked === true) {
@@ -298,14 +397,18 @@ export default function MyMoneyBlueprint() {
         return { ...prev, goalAreas: Array.from(existing) };
       });
     },
-    [updateStepData]
+    [markFieldTouched, updateStepData]
   );
 
   const handleSummaryConsent = React.useCallback(
     (checked) => {
+      if (checked === true) {
+        markFieldTouched('summary', 'shareEmail');
+      }
+      markFieldTouched('summary', 'consentToContact');
       updateStepData('summary', { consentToContact: checked === true });
     },
-    [updateStepData]
+    [markFieldTouched, updateStepData]
   );
 
   const summaryMessage = isLastStep
@@ -314,486 +417,732 @@ export default function MyMoneyBlueprint() {
       : 'Review your answers and generate a share code for this anonymised plan.'
     : 'Keep building your blueprint to unlock personalised recommendations.';
 
-  const renderBasicsStep = () => (
-    <div className="space-y-6">
-      <div className="grid gap-2">
-        <Label htmlFor="planName">Give your blueprint a nickname</Label>
-        <Input
-          id="planName"
-          placeholder="e.g. 2025 fresh start"
-          value={basics.planName ?? ''}
-          onChange={(event) => updateStepData('basics', { planName: event.target.value })}
-        />
-        <p className="text-xs text-muted-foreground">
-          The nickname is private and helps you recognise this blueprint later.
-        </p>
-      </div>
+  const renderBasicsStep = () => {
+    const guidance = MONEY_BLUEPRINT_GUIDANCE.basics;
+    const planNameError = getFieldError('basics', 'planName');
+    const householdSizeError = getFieldError('basics', 'householdSize');
+    const netIncomeError = getFieldError('basics', 'netIncome');
+    const incomeFrequencyError = getFieldError('basics', 'incomeFrequency');
+    const regionError = getFieldError('basics', 'region');
+    const focusError = getFieldError('basics', 'focus');
 
-      <div className="grid gap-4 md:grid-cols-2">
+    return (
+      <div className="space-y-6">
+        <StepGuidance {...guidance} />
+
         <div className="grid gap-2">
-          <Label htmlFor="householdSize">How many people rely on this plan?</Label>
+          <Label htmlFor="planName" className={cn(planNameError ? 'text-destructive' : '')}>
+            Give your blueprint a nickname
+          </Label>
           <Input
-            id="householdSize"
-            type="number"
-            inputMode="numeric"
-            min={1}
-            placeholder="e.g. 3"
-            value={basics.householdSize ?? ''}
-            onChange={(event) => updateStepData('basics', { householdSize: event.target.value })}
+            id="planName"
+            placeholder="e.g. 2025 fresh start"
+            value={basics.planName ?? ''}
+            onChange={(event) => updateStepData('basics', { planName: event.target.value })}
+            onBlur={() => markFieldTouched('basics', 'planName')}
+            aria-invalid={!!planNameError}
+            aria-describedby={planNameError ? 'planName-error' : 'planName-helper'}
+            className={cn(planNameError ? 'border-destructive focus-visible:ring-destructive/60' : '')}
           />
+          {planNameError ? (
+            <p id="planName-error" className="text-xs font-medium text-destructive">
+              {planNameError}
+            </p>
+          ) : (
+            <p id="planName-helper" className="text-xs text-muted-foreground">
+              The nickname is private and helps you recognise this blueprint later.
+            </p>
+          )}
         </div>
-        <div className="grid gap-2">
-          <Label htmlFor="netIncome">Combined take-home pay</Label>
-          <Input
-            id="netIncome"
-            type="number"
-            inputMode="decimal"
-            placeholder="e.g. 4200"
-            value={basics.netIncome ?? ''}
-            onChange={(event) => updateStepData('basics', { netIncome: event.target.value })}
-          />
-          <p className="text-xs text-muted-foreground">Enter the amount after tax for your household.</p>
-        </div>
-      </div>
 
-      <div className="grid gap-4 md:grid-cols-2">
-        <div className="grid gap-2">
-          <Label htmlFor="incomeFrequency">Income frequency</Label>
-          <Select
-            value={basics.incomeFrequency ?? 'monthly'}
-            onValueChange={(value) => updateStepData('basics', { incomeFrequency: value })}
-          >
-            <SelectTrigger id="incomeFrequency">
-              <SelectValue placeholder="Select frequency" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="monthly">Monthly</SelectItem>
-              <SelectItem value="four-weekly">Every 4 weeks</SelectItem>
-              <SelectItem value="fortnightly">Fortnightly</SelectItem>
-              <SelectItem value="weekly">Weekly</SelectItem>
-            </SelectContent>
-          </Select>
+        <div className="grid gap-4 md:grid-cols-2">
+          <div className="grid gap-2">
+            <Label htmlFor="householdSize" className={cn(householdSizeError ? 'text-destructive' : '')}>
+              How many people rely on this plan?
+            </Label>
+            <Input
+              id="householdSize"
+              type="number"
+              inputMode="numeric"
+              min={1}
+              placeholder="e.g. 3"
+              value={basics.householdSize ?? ''}
+              onChange={(event) => updateStepData('basics', { householdSize: event.target.value })}
+              onBlur={() => markFieldTouched('basics', 'householdSize')}
+              aria-invalid={!!householdSizeError}
+              aria-describedby={householdSizeError ? 'householdSize-error' : undefined}
+              className={cn(householdSizeError ? 'border-destructive focus-visible:ring-destructive/60' : '')}
+            />
+            {householdSizeError ? (
+              <p id="householdSize-error" className="text-xs font-medium text-destructive">
+                {householdSizeError}
+              </p>
+            ) : null}
+          </div>
+          <div className="grid gap-2">
+            <Label htmlFor="netIncome" className={cn(netIncomeError ? 'text-destructive' : '')}>
+              Combined take-home pay
+            </Label>
+            <Input
+              id="netIncome"
+              type="number"
+              inputMode="decimal"
+              placeholder="e.g. 4200"
+              value={basics.netIncome ?? ''}
+              onChange={(event) => updateStepData('basics', { netIncome: event.target.value })}
+              onBlur={() => markFieldTouched('basics', 'netIncome')}
+              aria-invalid={!!netIncomeError}
+              aria-describedby={netIncomeError ? 'netIncome-error' : 'netIncome-helper'}
+              className={cn(netIncomeError ? 'border-destructive focus-visible:ring-destructive/60' : '')}
+            />
+            {netIncomeError ? (
+              <p id="netIncome-error" className="text-xs font-medium text-destructive">
+                {netIncomeError}
+              </p>
+            ) : (
+              <p id="netIncome-helper" className="text-xs text-muted-foreground">
+                Enter the amount after tax for your household.
+              </p>
+            )}
+          </div>
         </div>
-        <div className="grid gap-2">
-          <Label htmlFor="region">Where in the UK do you live?</Label>
-          <Select
-            value={basics.region ?? ''}
-            onValueChange={(value) => updateStepData('basics', { region: value })}
-          >
-            <SelectTrigger id="region">
-              <SelectValue placeholder="Select a region" />
-            </SelectTrigger>
-            <SelectContent>
-              {regionOptions.map((option) => (
-                <SelectItem key={option.value} value={option.value}>
-                  {option.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
-      </div>
 
-      <div className="grid gap-2">
-        <Label htmlFor="focus">Main money focus for the next 12 months</Label>
-        <Select
-          value={basics.focus ?? ''}
-          onValueChange={(value) => updateStepData('basics', { focus: value })}
-        >
-          <SelectTrigger id="focus">
-            <SelectValue placeholder="Select your focus area" />
-          </SelectTrigger>
-          <SelectContent>
-            {focusOptions.map((option) => (
-              <SelectItem key={option.value} value={option.value}>
-                {option.label}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-      </div>
-    </div>
-  );
-
-  const renderPrioritiesStep = () => (
-    <div className="space-y-6">
-      <div className="flex flex-wrap items-center justify-between gap-3">
-        <div>
-          <Label>Which goals resonate right now?</Label>
-          <p className="text-xs text-muted-foreground">
-            Pick as many as apply. We use them to build your personalised checklist.
-          </p>
-        </div>
-        <Badge variant={goalsCount > 0 ? 'default' : 'outline'} className="uppercase tracking-wide">
-          {goalsCount} selected
-        </Badge>
-      </div>
-
-      <div className="grid gap-3 md:grid-cols-2">
-        {priorityOptions.map((option) => {
-          const isChecked = Array.isArray(priorities.goalAreas)
-            ? priorities.goalAreas.includes(option.value)
-            : false;
-          return (
-            <label
-              key={option.value}
-              htmlFor={`priority-${option.value}`}
-              className={cn(
-                'flex cursor-pointer items-start gap-3 rounded-xl border bg-card p-4 text-sm shadow-sm transition hover:border-primary/40 hover:shadow-md',
-                isChecked ? 'border-primary ring-2 ring-primary/20' : 'border-border'
-              )}
+        <div className="grid gap-4 md:grid-cols-2">
+          <div className="grid gap-2">
+            <Label htmlFor="incomeFrequency" className={cn(incomeFrequencyError ? 'text-destructive' : '')}>
+              Income frequency
+            </Label>
+            <Select
+              value={basics.incomeFrequency ?? 'monthly'}
+              onValueChange={(value) => {
+                markFieldTouched('basics', 'incomeFrequency');
+                updateStepData('basics', { incomeFrequency: value });
+              }}
             >
-              <Checkbox
-                id={`priority-${option.value}`}
-                checked={isChecked}
-                onCheckedChange={handlePriorityToggle(option.value)}
-              />
-              <span className="flex flex-col gap-1">
-                <span className="font-semibold text-foreground">{option.label}</span>
-                <span className="text-xs leading-snug text-muted-foreground">{option.description}</span>
-              </span>
-            </label>
-          );
-        })}
-      </div>
+              <SelectTrigger
+                id="incomeFrequency"
+                aria-invalid={!!incomeFrequencyError}
+                aria-describedby={incomeFrequencyError ? 'incomeFrequency-error' : undefined}
+                className={cn(incomeFrequencyError ? 'border-destructive focus:ring-destructive/60' : '')}
+              >
+                <SelectValue placeholder="Select frequency" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="monthly">Monthly</SelectItem>
+                <SelectItem value="four-weekly">Every 4 weeks</SelectItem>
+                <SelectItem value="fortnightly">Fortnightly</SelectItem>
+                <SelectItem value="weekly">Weekly</SelectItem>
+              </SelectContent>
+            </Select>
+            {incomeFrequencyError ? (
+              <p id="incomeFrequency-error" className="text-xs font-medium text-destructive">
+                {incomeFrequencyError}
+              </p>
+            ) : null}
+          </div>
+          <div className="grid gap-2">
+            <Label htmlFor="region" className={cn(regionError ? 'text-destructive' : '')}>
+              Where in the UK do you live?
+            </Label>
+            <Select
+              value={basics.region ?? ''}
+              onValueChange={(value) => {
+                markFieldTouched('basics', 'region');
+                updateStepData('basics', { region: value });
+              }}
+            >
+              <SelectTrigger
+                id="region"
+                aria-invalid={!!regionError}
+                aria-describedby={regionError ? 'region-error' : undefined}
+                className={cn(regionError ? 'border-destructive focus:ring-destructive/60' : '')}
+              >
+                <SelectValue placeholder="Select a region" />
+              </SelectTrigger>
+              <SelectContent>
+                {regionOptions.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {regionError ? (
+              <p id="region-error" className="text-xs font-medium text-destructive">
+                {regionError}
+              </p>
+            ) : null}
+          </div>
+        </div>
 
-      <div className="grid gap-2">
-        <Label htmlFor="topGoal">Describe your number one outcome</Label>
-        <Textarea
-          id="topGoal"
-          placeholder="e.g. Build a £6,000 emergency fund while clearing my credit card"
-          value={priorities.topGoal ?? ''}
-          onChange={(event) => updateStepData('priorities', { topGoal: event.target.value })}
-          rows={4}
-        />
-      </div>
-
-      <div className="grid gap-4 md:grid-cols-2">
         <div className="grid gap-2">
-          <Label htmlFor="timeline">Ideal timeframe</Label>
+          <Label htmlFor="focus" className={cn(focusError ? 'text-destructive' : '')}>
+            Main money focus for the next 12 months
+          </Label>
           <Select
-            value={priorities.timeline ?? ''}
-            onValueChange={(value) => updateStepData('priorities', { timeline: value })}
+            value={basics.focus ?? ''}
+            onValueChange={(value) => {
+              markFieldTouched('basics', 'focus');
+              updateStepData('basics', { focus: value });
+            }}
           >
-            <SelectTrigger id="timeline">
-              <SelectValue placeholder="Select a timeline" />
+            <SelectTrigger
+              id="focus"
+              aria-invalid={!!focusError}
+              aria-describedby={focusError ? 'focus-error' : undefined}
+              className={cn(focusError ? 'border-destructive focus:ring-destructive/60' : '')}
+            >
+              <SelectValue placeholder="Select your focus area" />
             </SelectTrigger>
             <SelectContent>
-              {timelineOptions.map((option) => (
+              {focusOptions.map((option) => (
                 <SelectItem key={option.value} value={option.value}>
                   {option.label}
                 </SelectItem>
               ))}
             </SelectContent>
           </Select>
-        </div>
-        <div className="grid gap-2">
-          <Label htmlFor="savingsTarget">Target amount (optional)</Label>
-          <Input
-            id="savingsTarget"
-            type="number"
-            inputMode="decimal"
-            placeholder="e.g. 6000"
-            value={priorities.savingsTarget ?? ''}
-            onChange={(event) => updateStepData('priorities', { savingsTarget: event.target.value })}
-          />
+          {focusError ? (
+            <p id="focus-error" className="text-xs font-medium text-destructive">
+              {focusError}
+            </p>
+          ) : null}
         </div>
       </div>
-    </div>
-  );
+    );
+  };
 
-  const renderHabitsStep = () => (
-    <div className="space-y-6">
-      <div className="space-y-3">
-        <Label>Which statement fits your budgeting style?</Label>
-        <RadioGroup
-          value={habits.budgetingStyle ?? ''}
-          onValueChange={(value) => updateStepData('habits', { budgetingStyle: value })}
-          className="grid gap-3 md:grid-cols-3"
-        >
-          {budgetingStyles.map((style) => {
-            const isActive = habits.budgetingStyle === style.value;
+  const renderPrioritiesStep = () => {
+    const guidance = MONEY_BLUEPRINT_GUIDANCE.priorities;
+    const goalAreasError = getFieldError('priorities', 'goalAreas');
+    const topGoalError = getFieldError('priorities', 'topGoal');
+    const timelineError = getFieldError('priorities', 'timeline');
+    const savingsTargetError = getFieldError('priorities', 'savingsTarget');
+
+    return (
+      <div className="space-y-6">
+        <StepGuidance {...guidance} />
+
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <Label className={cn(goalAreasError ? 'text-destructive' : '')}>Which goals resonate right now?</Label>
+            <p className="text-xs text-muted-foreground">
+              Pick as many as apply. We use them to build your personalised checklist.
+            </p>
+            {goalAreasError ? (
+              <p id="goalAreas-error" className="text-xs font-medium text-destructive">
+                {goalAreasError}
+              </p>
+            ) : null}
+          </div>
+          <Badge variant={goalsCount > 0 ? 'default' : 'outline'} className="uppercase tracking-wide">
+            {goalsCount} selected
+          </Badge>
+        </div>
+
+        <div className="grid gap-3 md:grid-cols-2" role="group" aria-invalid={!!goalAreasError}>
+          {priorityOptions.map((option) => {
+            const isChecked = Array.isArray(priorities.goalAreas)
+              ? priorities.goalAreas.includes(option.value)
+              : false;
             return (
               <label
-                key={style.value}
-                htmlFor={`budget-style-${style.value}`}
+                key={option.value}
+                htmlFor={`priority-${option.value}`}
                 className={cn(
-                  'flex cursor-pointer flex-col gap-2 rounded-xl border bg-card p-4 text-left shadow-sm transition hover:border-primary/40 hover:shadow-md',
-                  isActive ? 'border-primary ring-2 ring-primary/20' : 'border-border'
+                  'flex cursor-pointer items-start gap-3 rounded-xl border bg-card p-4 text-sm shadow-sm transition hover:border-primary/40 hover:shadow-md',
+                  isChecked ? 'border-primary ring-2 ring-primary/20' : 'border-border',
+                  goalAreasError ? 'border-destructive/70' : ''
                 )}
               >
-                <div className="flex items-center gap-2">
-                  <RadioGroupItem value={style.value} id={`budget-style-${style.value}`} />
-                  <span className="font-semibold text-foreground">{style.title}</span>
-                </div>
-                <span className="text-xs text-muted-foreground">{style.description}</span>
+                <Checkbox
+                  id={`priority-${option.value}`}
+                  checked={isChecked}
+                  onCheckedChange={handlePriorityToggle(option.value)}
+                  aria-describedby={goalAreasError ? 'goalAreas-error' : undefined}
+                />
+                <span className="flex flex-col gap-1">
+                  <span className="font-semibold text-foreground">{option.label}</span>
+                  <span className="text-xs leading-snug text-muted-foreground">{option.description}</span>
+                </span>
               </label>
             );
           })}
-        </RadioGroup>
-      </div>
+        </div>
 
-      <div className="grid gap-4 md:grid-cols-2">
         <div className="grid gap-2">
-          <Label htmlFor="confidenceLevel">How confident do you feel managing money?</Label>
-          <Select
-            value={habits.confidenceLevel ?? ''}
-            onValueChange={(value) => updateStepData('habits', { confidenceLevel: value })}
-          >
-            <SelectTrigger id="confidenceLevel">
-              <SelectValue placeholder="Select a confidence level" />
-            </SelectTrigger>
-            <SelectContent>
-              {confidenceOptions.map((option) => (
-                <SelectItem key={option.value} value={option.value}>
-                  {option.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
-        <div className="grid gap-2">
-          <Label htmlFor="checkInFrequency">How often do you check in with your finances?</Label>
-          <Select
-            value={habits.checkInFrequency ?? ''}
-            onValueChange={(value) => updateStepData('habits', { checkInFrequency: value })}
-          >
-            <SelectTrigger id="checkInFrequency">
-              <SelectValue placeholder="Select a cadence" />
-            </SelectTrigger>
-            <SelectContent>
-              {checkInOptions.map((option) => (
-                <SelectItem key={option.value} value={option.value}>
-                  {option.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
-      </div>
-
-      <div className="grid gap-4 md:grid-cols-2">
-        <div className="grid gap-2">
-          <Label htmlFor="emergencyFund">Current emergency fund coverage</Label>
-          <Select
-            value={habits.emergencyFundMonths ?? ''}
-            onValueChange={(value) => updateStepData('habits', { emergencyFundMonths: value })}
-          >
-            <SelectTrigger id="emergencyFund">
-              <SelectValue placeholder="Select an estimate" />
-            </SelectTrigger>
-            <SelectContent>
-              {emergencyFundOptions.map((option) => (
-                <SelectItem key={option.value} value={option.value}>
-                  {option.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
-        <div className="grid gap-2">
-          <Label htmlFor="notes">Any habits or challenges worth noting?</Label>
+          <Label htmlFor="topGoal" className={cn(topGoalError ? 'text-destructive' : '')}>
+            Describe your number one outcome
+          </Label>
           <Textarea
-            id="notes"
+            id="topGoal"
+            placeholder="e.g. Build a £6,000 emergency fund while clearing my credit card"
+            value={priorities.topGoal ?? ''}
+            onChange={(event) => updateStepData('priorities', { topGoal: event.target.value })}
+            onBlur={() => markFieldTouched('priorities', 'topGoal')}
             rows={4}
-            placeholder="e.g. Automating savings works, but unexpected car costs knock me off course"
-            value={habits.additionalNotes ?? ''}
-            onChange={(event) => updateStepData('habits', { additionalNotes: event.target.value })}
+            aria-invalid={!!topGoalError}
+            aria-describedby={topGoalError ? 'topGoal-error' : undefined}
+            className={cn(topGoalError ? 'border-destructive focus-visible:ring-destructive/60' : '')}
           />
+          {topGoalError ? (
+            <p id="topGoal-error" className="text-xs font-medium text-destructive">
+              {topGoalError}
+            </p>
+          ) : null}
         </div>
-      </div>
-    </div>
-  );
 
-  const renderSummaryStep = () => (
-    <div className="space-y-6">
-      <div className="rounded-2xl border border-primary/30 bg-primary/5 p-6 shadow-sm">
-        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-          <div className="space-y-2">
-            <p className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-primary">
-              <Sparkles className="h-4 w-4" /> Share code ready
-            </p>
-            <h3 className="text-xl font-semibold text-primary">{formattedReportId || 'Generating…'}</h3>
-            <p className="text-sm text-primary/80">
-              Use this anonymised code when sharing your blueprint with a partner, coach or adviser.
-            </p>
-            {completionTimestamp ? (
-              <p className="text-xs text-primary/70">Generated on {completionTimestamp}</p>
+        <div className="grid gap-4 md:grid-cols-2">
+          <div className="grid gap-2">
+            <Label htmlFor="timeline" className={cn(timelineError ? 'text-destructive' : '')}>
+              Ideal timeframe
+            </Label>
+            <Select
+              value={priorities.timeline ?? ''}
+              onValueChange={(value) => {
+                markFieldTouched('priorities', 'timeline');
+                updateStepData('priorities', { timeline: value });
+              }}
+            >
+              <SelectTrigger
+                id="timeline"
+                aria-invalid={!!timelineError}
+                aria-describedby={timelineError ? 'timeline-error' : undefined}
+                className={cn(timelineError ? 'border-destructive focus:ring-destructive/60' : '')}
+              >
+                <SelectValue placeholder="Select a timeline" />
+              </SelectTrigger>
+              <SelectContent>
+                {timelineOptions.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {timelineError ? (
+              <p id="timeline-error" className="text-xs font-medium text-destructive">
+                {timelineError}
+              </p>
             ) : null}
           </div>
-          <div className="flex flex-col gap-2 sm:items-end">
-            <Badge
-              variant="outline"
-              className="border-primary/50 bg-white/70 px-4 py-2 text-sm font-semibold tracking-[0.35em] text-primary"
-            >
-              {formattedReportId || 'PENDING'}
-            </Badge>
-            <Button
-              type="button"
-              variant="secondary"
-              onClick={handleCopyReportId}
-              className="gap-2"
-            >
-              <Copy className="h-4 w-4" /> Copy code
-            </Button>
+          <div className="grid gap-2">
+            <Label htmlFor="savingsTarget" className={cn(savingsTargetError ? 'text-destructive' : '')}>
+              Target amount (optional)
+            </Label>
+            <Input
+              id="savingsTarget"
+              type="number"
+              inputMode="decimal"
+              placeholder="e.g. 6000"
+              value={priorities.savingsTarget ?? ''}
+              onChange={(event) => updateStepData('priorities', { savingsTarget: event.target.value })}
+              onBlur={() => markFieldTouched('priorities', 'savingsTarget')}
+              aria-invalid={!!savingsTargetError}
+              aria-describedby={savingsTargetError ? 'savingsTarget-error' : undefined}
+              className={cn(savingsTargetError ? 'border-destructive focus-visible:ring-destructive/60' : '')}
+            />
+            {savingsTargetError ? (
+              <p id="savingsTarget-error" className="text-xs font-medium text-destructive">
+                {savingsTargetError}
+              </p>
+            ) : (
+              <p className="text-xs text-muted-foreground">Leave blank if you do not have a number in mind.</p>
+            )}
           </div>
         </div>
       </div>
+    );
+  };
 
-      <div className="grid gap-6 md:grid-cols-2">
+  const renderHabitsStep = () => {
+    const guidance = MONEY_BLUEPRINT_GUIDANCE.habits;
+    const budgetingStyleError = getFieldError('habits', 'budgetingStyle');
+    const confidenceLevelError = getFieldError('habits', 'confidenceLevel');
+    const checkInFrequencyError = getFieldError('habits', 'checkInFrequency');
+    const emergencyFundError = getFieldError('habits', 'emergencyFundMonths');
+    const additionalNotesError = getFieldError('habits', 'additionalNotes');
+
+    return (
+      <div className="space-y-6">
+        <StepGuidance {...guidance} />
+
+        <div className="space-y-3">
+          <Label className={cn(budgetingStyleError ? 'text-destructive' : '')}>
+            Which statement fits your budgeting style?
+          </Label>
+          {budgetingStyleError ? (
+            <p id="budgetingStyle-error" className="text-xs font-medium text-destructive">
+              {budgetingStyleError}
+            </p>
+          ) : null}
+          <RadioGroup
+            value={habits.budgetingStyle ?? ''}
+            onValueChange={(value) => {
+              markFieldTouched('habits', 'budgetingStyle');
+              updateStepData('habits', { budgetingStyle: value });
+            }}
+            className="grid gap-3 md:grid-cols-3"
+            aria-invalid={!!budgetingStyleError}
+            aria-describedby={budgetingStyleError ? 'budgetingStyle-error' : undefined}
+          >
+            {budgetingStyles.map((style) => {
+              const isActive = habits.budgetingStyle === style.value;
+              return (
+                <label
+                  key={style.value}
+                  htmlFor={`budget-style-${style.value}`}
+                  className={cn(
+                    'flex cursor-pointer flex-col gap-2 rounded-xl border bg-card p-4 text-left shadow-sm transition hover:border-primary/40 hover:shadow-md',
+                    isActive ? 'border-primary ring-2 ring-primary/20' : 'border-border',
+                    budgetingStyleError ? 'border-destructive/70' : ''
+                  )}
+                >
+                  <div className="flex items-center gap-2">
+                    <RadioGroupItem value={style.value} id={`budget-style-${style.value}`} />
+                    <span className="font-semibold text-foreground">{style.title}</span>
+                  </div>
+                  <span className="text-xs text-muted-foreground">{style.description}</span>
+                </label>
+              );
+            })}
+          </RadioGroup>
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-2">
+          <div className="grid gap-2">
+            <Label htmlFor="confidenceLevel" className={cn(confidenceLevelError ? 'text-destructive' : '')}>
+              How confident do you feel managing money?
+            </Label>
+            <Select
+              value={habits.confidenceLevel ?? ''}
+              onValueChange={(value) => {
+                markFieldTouched('habits', 'confidenceLevel');
+                updateStepData('habits', { confidenceLevel: value });
+              }}
+            >
+              <SelectTrigger
+                id="confidenceLevel"
+                aria-invalid={!!confidenceLevelError}
+                aria-describedby={confidenceLevelError ? 'confidenceLevel-error' : undefined}
+                className={cn(confidenceLevelError ? 'border-destructive focus:ring-destructive/60' : '')}
+              >
+                <SelectValue placeholder="Select a confidence level" />
+              </SelectTrigger>
+              <SelectContent>
+                {confidenceOptions.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {confidenceLevelError ? (
+              <p id="confidenceLevel-error" className="text-xs font-medium text-destructive">
+                {confidenceLevelError}
+              </p>
+            ) : null}
+          </div>
+          <div className="grid gap-2">
+            <Label htmlFor="checkInFrequency" className={cn(checkInFrequencyError ? 'text-destructive' : '')}>
+              How often do you check in with your finances?
+            </Label>
+            <Select
+              value={habits.checkInFrequency ?? ''}
+              onValueChange={(value) => {
+                markFieldTouched('habits', 'checkInFrequency');
+                updateStepData('habits', { checkInFrequency: value });
+              }}
+            >
+              <SelectTrigger
+                id="checkInFrequency"
+                aria-invalid={!!checkInFrequencyError}
+                aria-describedby={checkInFrequencyError ? 'checkInFrequency-error' : undefined}
+                className={cn(checkInFrequencyError ? 'border-destructive focus:ring-destructive/60' : '')}
+              >
+                <SelectValue placeholder="Select a cadence" />
+              </SelectTrigger>
+              <SelectContent>
+                {checkInOptions.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {checkInFrequencyError ? (
+              <p id="checkInFrequency-error" className="text-xs font-medium text-destructive">
+                {checkInFrequencyError}
+              </p>
+            ) : null}
+          </div>
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-2">
+          <div className="grid gap-2">
+            <Label htmlFor="emergencyFund" className={cn(emergencyFundError ? 'text-destructive' : '')}>
+              Current emergency fund coverage
+            </Label>
+            <Select
+              value={habits.emergencyFundMonths ?? ''}
+              onValueChange={(value) => {
+                markFieldTouched('habits', 'emergencyFundMonths');
+                updateStepData('habits', { emergencyFundMonths: value });
+              }}
+            >
+              <SelectTrigger
+                id="emergencyFund"
+                aria-invalid={!!emergencyFundError}
+                aria-describedby={emergencyFundError ? 'emergencyFund-error' : undefined}
+                className={cn(emergencyFundError ? 'border-destructive focus:ring-destructive/60' : '')}
+              >
+                <SelectValue placeholder="Select an estimate" />
+              </SelectTrigger>
+              <SelectContent>
+                {emergencyFundOptions.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {emergencyFundError ? (
+              <p id="emergencyFund-error" className="text-xs font-medium text-destructive">
+                {emergencyFundError}
+              </p>
+            ) : null}
+          </div>
+          <div className="grid gap-2">
+            <Label htmlFor="notes" className={cn(additionalNotesError ? 'text-destructive' : '')}>
+              Any habits or challenges worth noting?
+            </Label>
+            <Textarea
+              id="notes"
+              rows={4}
+              placeholder="e.g. Automating savings works, but unexpected car costs knock me off course"
+              value={habits.additionalNotes ?? ''}
+              onChange={(event) => updateStepData('habits', { additionalNotes: event.target.value })}
+              onBlur={() => markFieldTouched('habits', 'additionalNotes')}
+              aria-invalid={!!additionalNotesError}
+              aria-describedby={additionalNotesError ? 'additionalNotes-error' : undefined}
+              className={cn(additionalNotesError ? 'border-destructive focus-visible:ring-destructive/60' : '')}
+            />
+            {additionalNotesError ? (
+              <p id="additionalNotes-error" className="text-xs font-medium text-destructive">
+                {additionalNotesError}
+              </p>
+            ) : (
+              <p className="text-xs text-muted-foreground">Optional, but it helps capture behaviours to celebrate or improve.</p>
+            )}
+          </div>
+        </div>
+      </div>
+    );
+  };
+
+  const renderSummaryStep = () => {
+    const guidance = MONEY_BLUEPRINT_GUIDANCE.summary;
+    const shareEmailError = getFieldError('summary', 'shareEmail');
+
+    return (
+      <div className="space-y-6">
+        <StepGuidance {...guidance} />
+
+        <div className="rounded-2xl border border-primary/30 bg-primary/5 p-6 shadow-sm">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+            <div className="space-y-2">
+              <p className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-primary">
+                <Sparkles className="h-4 w-4" /> Share code ready
+              </p>
+              <h3 className="text-xl font-semibold text-primary">{formattedReportId || 'Generating…'}</h3>
+              <p className="text-sm text-primary/80">
+                Use this anonymised code when sharing your blueprint with a partner, coach or adviser.
+              </p>
+              {completionTimestamp ? (
+                <p className="text-xs text-primary/70">Generated on {completionTimestamp}</p>
+              ) : null}
+            </div>
+            <div className="flex flex-col gap-2 sm:items-end">
+              <Badge
+                variant="outline"
+                className="border-primary/50 bg-white/70 px-4 py-2 text-sm font-semibold tracking-[0.35em] text-primary"
+              >
+                {formattedReportId || '---- ---- ----'}
+              </Badge>
+              <Button variant="outline" size="sm" className="gap-2" onClick={handleCopyReportId}>
+                <Copy className="h-4 w-4" /> Copy share code
+              </Button>
+            </div>
+          </div>
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-2">
+          <div className="rounded-xl border border-border/60 bg-card p-5 shadow-sm">
+            <h3 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Household snapshot</h3>
+            <dl className="mt-4 space-y-3 text-sm">
+              <div className="flex items-start justify-between gap-4">
+                <dt className="font-medium text-foreground">Plan nickname</dt>
+                <dd className="text-right text-muted-foreground">
+                  {basics.planName?.trim() || 'Add a nickname to personalise this plan.'}
+                </dd>
+              </div>
+              <div className="flex items-start justify-between gap-4">
+                <dt className="font-medium text-foreground">Household size</dt>
+                <dd className="text-right text-muted-foreground">{basics.householdSize || 'Not set'}</dd>
+              </div>
+              <div className="flex items-start justify-between gap-4">
+                <dt className="font-medium text-foreground">Net income</dt>
+                <dd className="text-right text-muted-foreground">{formatCurrency(basics.netIncome)}</dd>
+              </div>
+              <div className="flex items-start justify-between gap-4">
+                <dt className="font-medium text-foreground">Income frequency</dt>
+                <dd className="text-right text-muted-foreground">{basics.incomeFrequency}</dd>
+              </div>
+              <div className="flex items-start justify-between gap-4">
+                <dt className="font-medium text-foreground">Region</dt>
+                <dd className="text-right text-muted-foreground">
+                  {regionOptions.find((option) => option.value === basics.region)?.label || 'Not set'}
+                </dd>
+              </div>
+              <div className="flex items-start justify-between gap-4">
+                <dt className="font-medium text-foreground">Primary focus</dt>
+                <dd className="text-right text-muted-foreground">
+                  {focusOptions.find((option) => option.value === basics.focus)?.label || 'Not set'}
+                </dd>
+              </div>
+            </dl>
+          </div>
+
+          <div className="rounded-xl border border-border/60 bg-card p-5 shadow-sm">
+            <h3 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+              Priorities & milestones
+            </h3>
+            <div className="mt-4 space-y-3 text-sm">
+              <div className="flex flex-wrap gap-2">
+                {(priorities.goalAreas || []).length > 0 ? (
+                  priorities.goalAreas.map((goal) => {
+                    const option = priorityOptions.find((item) => item.value === goal);
+                    return (
+                      <Badge key={goal} variant="secondary" className="text-xs">
+                        {option?.label || goal}
+                      </Badge>
+                    );
+                  })
+                ) : (
+                  <span className="text-muted-foreground">No goals selected yet.</span>
+                )}
+              </div>
+              <div>
+                <p className="font-medium text-foreground">Headline goal</p>
+                <p className="text-sm text-muted-foreground">
+                  {priorities.topGoal?.trim() || 'Add a short description of your most important outcome.'}
+                </p>
+              </div>
+              <div className="flex items-start justify-between gap-4">
+                <span className="font-medium text-foreground">Timeline</span>
+                <span className="text-right text-muted-foreground">
+                  {timelineOptions.find((option) => option.value === priorities.timeline)?.label || 'Not set'}
+                </span>
+              </div>
+              <div className="flex items-start justify-between gap-4">
+                <span className="font-medium text-foreground">Target amount</span>
+                <span className="text-right text-muted-foreground">
+                  {priorities.savingsTarget?.trim() ? formatCurrency(priorities.savingsTarget) : 'Optional'}
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+
         <div className="rounded-xl border border-border/60 bg-card p-5 shadow-sm">
           <h3 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
-            Household snapshot
+            Habits & resilience
           </h3>
           <dl className="mt-4 space-y-3 text-sm">
             <div className="flex items-start justify-between gap-4">
-              <dt className="font-medium text-foreground">Plan nickname</dt>
+              <dt className="font-medium text-foreground">Budgeting style</dt>
               <dd className="text-right text-muted-foreground">
-                {basics.planName?.trim() || 'Not set'}
+                {budgetingStyles.find((option) => option.value === habits.budgetingStyle)?.title || 'Not set'}
               </dd>
             </div>
             <div className="flex items-start justify-between gap-4">
-              <dt className="font-medium text-foreground">Household size</dt>
+              <dt className="font-medium text-foreground">Confidence level</dt>
               <dd className="text-right text-muted-foreground">
-                {basics.householdSize?.trim() || 'Not set'}
+                {confidenceOptions.find((option) => option.value === habits.confidenceLevel)?.label || 'Not set'}
               </dd>
             </div>
             <div className="flex items-start justify-between gap-4">
-              <dt className="font-medium text-foreground">Take-home pay</dt>
+              <dt className="font-medium text-foreground">Check-in cadence</dt>
               <dd className="text-right text-muted-foreground">
-                {formatCurrency(basics.netIncome)} per {basics.incomeFrequency || 'month'}
+                {checkInOptions.find((option) => option.value === habits.checkInFrequency)?.label || 'Not set'}
               </dd>
             </div>
             <div className="flex items-start justify-between gap-4">
-              <dt className="font-medium text-foreground">Region</dt>
+              <dt className="font-medium text-foreground">Emergency fund</dt>
               <dd className="text-right text-muted-foreground">
-                {regionOptions.find((option) => option.value === basics.region)?.label || 'Not set'}
+                {emergencyFundOptions.find((option) => option.value === habits.emergencyFundMonths)?.label || 'Not set'}
               </dd>
             </div>
-            <div className="flex items-start justify-between gap-4">
-              <dt className="font-medium text-foreground">Focus</dt>
-              <dd className="text-right text-muted-foreground">
-                {focusOptions.find((option) => option.value === basics.focus)?.label || 'Not set'}
+            <div className="flex flex-col gap-2">
+              <dt className="font-medium text-foreground">Notes</dt>
+              <dd className="text-sm text-muted-foreground whitespace-pre-line">
+                {habits.additionalNotes?.trim() || 'Use this space to record habits, triggers or wins you want to remember.'}
               </dd>
             </div>
           </dl>
         </div>
 
-        <div className="rounded-xl border border-border/60 bg-card p-5 shadow-sm">
-          <h3 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
-            Priorities & milestones
-          </h3>
-          <div className="mt-4 space-y-3 text-sm">
-            <div className="flex flex-wrap gap-2">
-              {(priorities.goalAreas || []).length > 0 ? (
-                priorities.goalAreas.map((goal) => {
-                  const option = priorityOptions.find((item) => item.value === goal);
-                  return (
-                    <Badge key={goal} variant="secondary" className="text-xs">
-                      {option?.label || goal}
-                    </Badge>
-                  );
-                })
-              ) : (
-                <span className="text-muted-foreground">No goals selected yet.</span>
-              )}
-            </div>
-            <div>
-              <p className="font-medium text-foreground">Headline goal</p>
-              <p className="text-sm text-muted-foreground">
-                {priorities.topGoal?.trim() || 'Add a short description of your most important outcome.'}
+        <div className="space-y-3">
+          <div className="grid gap-2">
+            <Label htmlFor="shareEmail" className={cn(shareEmailError ? 'text-destructive' : '')}>
+              Email a copy to yourself (optional)
+            </Label>
+            <Input
+              id="shareEmail"
+              type="email"
+              placeholder="you@example.com"
+              value={summary.shareEmail ?? ''}
+              onChange={(event) => updateStepData('summary', { shareEmail: event.target.value })}
+              onBlur={() => markFieldTouched('summary', 'shareEmail')}
+              aria-invalid={!!shareEmailError}
+              aria-describedby={shareEmailError ? 'shareEmail-error' : undefined}
+              className={cn(shareEmailError ? 'border-destructive focus-visible:ring-destructive/60' : '')}
+            />
+            {shareEmailError ? (
+              <p id="shareEmail-error" className="text-xs font-medium text-destructive">
+                {shareEmailError}
               </p>
-            </div>
-            <div className="flex items-start justify-between gap-4">
-              <span className="font-medium text-foreground">Timeline</span>
-              <span className="text-right text-muted-foreground">
-                {timelineOptions.find((option) => option.value === priorities.timeline)?.label || 'Not set'}
+            ) : (
+              <p className="text-xs text-muted-foreground">We only send you a reminder if you choose to opt in.</p>
+            )}
+          </div>
+          <label className="flex items-start gap-3 text-sm text-muted-foreground">
+            <Checkbox
+              id="consentToContact"
+              checked={!!summary.consentToContact}
+              onCheckedChange={handleSummaryConsent}
+              aria-describedby={shareEmailError ? 'shareEmail-error' : undefined}
+            />
+            <span>
+              <span className="font-medium text-foreground">Email me a reminder to review this plan</span>
+              <span className="block text-xs text-muted-foreground">
+                We only store your share code and email if you opt in. You can unsubscribe at any time.
               </span>
-            </div>
-            <div className="flex items-start justify-between gap-4">
-              <span className="font-medium text-foreground">Target amount</span>
-              <span className="text-right text-muted-foreground">
-                {priorities.savingsTarget?.trim() ? formatCurrency(priorities.savingsTarget) : 'Optional'}
-              </span>
-            </div>
-          </div>
-        </div>
-      </div>
-
-      <div className="rounded-xl border border-border/60 bg-card p-5 shadow-sm">
-        <h3 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
-          Habits & resilience
-        </h3>
-        <dl className="mt-4 space-y-3 text-sm">
-          <div className="flex items-start justify-between gap-4">
-            <dt className="font-medium text-foreground">Budgeting style</dt>
-            <dd className="text-right text-muted-foreground">
-              {budgetingStyles.find((option) => option.value === habits.budgetingStyle)?.title || 'Not set'}
-            </dd>
-          </div>
-          <div className="flex items-start justify-between gap-4">
-            <dt className="font-medium text-foreground">Confidence level</dt>
-            <dd className="text-right text-muted-foreground">
-              {confidenceOptions.find((option) => option.value === habits.confidenceLevel)?.label || 'Not set'}
-            </dd>
-          </div>
-          <div className="flex items-start justify-between gap-4">
-            <dt className="font-medium text-foreground">Check-in cadence</dt>
-            <dd className="text-right text-muted-foreground">
-              {checkInOptions.find((option) => option.value === habits.checkInFrequency)?.label || 'Not set'}
-            </dd>
-          </div>
-          <div className="flex items-start justify-between gap-4">
-            <dt className="font-medium text-foreground">Emergency fund</dt>
-            <dd className="text-right text-muted-foreground">
-              {emergencyFundOptions.find((option) => option.value === habits.emergencyFundMonths)?.label || 'Not set'}
-            </dd>
-          </div>
-          <div className="flex flex-col gap-2">
-            <dt className="font-medium text-foreground">Notes</dt>
-            <dd className="text-sm text-muted-foreground whitespace-pre-line">
-              {habits.additionalNotes?.trim() || 'Use this space to record habits, triggers or wins you want to remember.'}
-            </dd>
-          </div>
-        </dl>
-      </div>
-
-      <div className="space-y-3">
-        <div className="grid gap-2">
-          <Label htmlFor="shareEmail">Email a copy to yourself (optional)</Label>
-          <Input
-            id="shareEmail"
-            type="email"
-            placeholder="you@example.com"
-            value={summary.shareEmail ?? ''}
-            onChange={(event) => updateStepData('summary', { shareEmail: event.target.value })}
-          />
-        </div>
-        <label className="flex items-start gap-3 text-sm text-muted-foreground">
-          <Checkbox
-            id="consentToContact"
-            checked={!!summary.consentToContact}
-            onCheckedChange={handleSummaryConsent}
-          />
-          <span>
-            <span className="font-medium text-foreground">Email me a reminder to review this plan</span>
-            <span className="block text-xs text-muted-foreground">
-              We only store your share code and email if you opt in. You can unsubscribe at any time.
             </span>
-          </span>
-        </label>
-      </div>
-
-      {isComplete ? (
-        <div className="rounded-xl border border-emerald-400/60 bg-emerald-50/80 p-4 text-sm text-emerald-800 dark:bg-emerald-500/10 dark:text-emerald-100">
-          <p className="font-semibold">Blueprint saved</p>
-          <p className="mt-1">
-            Share the code above or revisit any step to refresh your plan. Updating answers will create a new snapshot.
-          </p>
+          </label>
         </div>
-      ) : null}
-    </div>
-  );
+
+        {isComplete ? (
+          <div className="rounded-xl border border-emerald-400/60 bg-emerald-50/80 p-4 text-sm text-emerald-800 dark:bg-emerald-500/10 dark:text-emerald-100">
+            <p className="font-semibold">Blueprint saved</p>
+            <p className="mt-1">
+              Share the code above or revisit any step to refresh your plan. Updating answers will create a new snapshot.
+            </p>
+          </div>
+        ) : null}
+      </div>
+    );
+  };
 
   const renderStepContent = () => {
     switch (currentStep?.id) {


### PR DESCRIPTION
## Summary
- add a shared Money Blueprint schema with zod validation rules and guidance copy for each step
- introduce a StepGuidance helper component and export to wizard index for reuse
- wire the wizard page to validate per-step data, show inline errors, and surface contextual guidance before advancing

## Testing
- npm run lint *(fails: cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68fa4a5047b08320a93e3664b2f7f2c1