### PR TITLE
Add Money Blueprint insight formatter, prompt builder, and AI hook

### DIFF
--- a/src/api/moneyBlueprint.js
+++ b/src/api/moneyBlueprint.js
@@ -1,0 +1,205 @@
+import { InvokeLLM } from './integrations';
+
+const getRuntimeEnv = () => {
+  if (typeof import.meta !== 'undefined' && import.meta.env) {
+    return import.meta.env;
+  }
+  if (typeof process !== 'undefined' && process.env) {
+    return process.env;
+  }
+  return {};
+};
+
+const ENV = getRuntimeEnv();
+
+const getEnvValue = (...keys) => {
+  for (const key of keys) {
+    if (key in ENV && ENV[key] !== undefined) {
+      return ENV[key];
+    }
+  }
+  return undefined;
+};
+
+const DEFAULT_PROVIDER = getEnvValue(
+  'VITE_BLUEPRINT_AI_PROVIDER',
+  'NEXT_PUBLIC_BLUEPRINT_AI_PROVIDER',
+  'BLUEPRINT_AI_PROVIDER'
+);
+
+const DEFAULT_ENDPOINT = getEnvValue(
+  'VITE_BLUEPRINT_AI_ENDPOINT',
+  'NEXT_PUBLIC_BLUEPRINT_AI_ENDPOINT',
+  'BLUEPRINT_AI_ENDPOINT'
+);
+
+const DEFAULT_HTTP_ENDPOINT = '/api/blueprint-ai';
+
+const pickEndpoint = (explicitEndpoint) => explicitEndpoint ?? DEFAULT_ENDPOINT ?? DEFAULT_HTTP_ENDPOINT;
+
+const extractFromArrayContent = (value) => {
+  if (!Array.isArray(value)) return undefined;
+  return value
+    .map((item) => {
+      if (!item) return '';
+      if (typeof item === 'string') return item;
+      if (typeof item === 'object') {
+        return item.text ?? item.content ?? item.value ?? '';
+      }
+      return `${item}`;
+    })
+    .filter(Boolean)
+    .join('\n');
+};
+
+const extractAiContent = (payload) => {
+  if (!payload) return '';
+  if (typeof payload === 'string') return payload;
+
+  if (typeof payload.content === 'string') return payload.content;
+  const arrayContent = extractFromArrayContent(payload.content);
+  if (arrayContent) return arrayContent;
+
+  if (payload.message && typeof payload.message.content === 'string') {
+    return payload.message.content;
+  }
+
+  if (Array.isArray(payload.choices)) {
+    const choiceContent = payload.choices
+      .map((choice) => {
+        if (typeof choice === 'string') return choice;
+        if (choice?.message?.content) return choice.message.content;
+        return extractFromArrayContent(choice?.message?.content) ?? choice?.text ?? '';
+      })
+      .filter(Boolean)
+      .join('\n\n');
+    if (choiceContent) return choiceContent;
+  }
+
+  if (payload.data) {
+    const data = payload.data;
+    if (typeof data === 'string') return data;
+    const dataArrayContent = extractFromArrayContent(data);
+    if (dataArrayContent) return dataArrayContent;
+    if (Array.isArray(data?.choices)) {
+      const combined = data.choices
+        .map((choice) => {
+          if (choice?.message?.content) return choice.message.content;
+          if (Array.isArray(choice?.message?.content)) {
+            return extractFromArrayContent(choice.message.content);
+          }
+          return choice?.text ?? '';
+        })
+        .filter(Boolean)
+        .join('\n\n');
+      if (combined) return combined;
+    }
+    if (typeof data?.output_text === 'string') return data.output_text;
+  }
+
+  if (typeof payload.result === 'string') return payload.result;
+  if (typeof payload.output === 'string') return payload.output;
+  if (typeof payload.response === 'string') return payload.response;
+
+  return '';
+};
+
+const prepareBasePayload = (prompt) => ({
+  reportId: prompt.reportId ?? null,
+  messages: prompt.messages ?? [],
+  summaryBullets: prompt.summaryBullets ?? [],
+  riskFlags: prompt.riskFlags ?? [],
+  data: prompt.sanitisedData ?? {},
+  disclaimer: prompt.disclaimer ?? null,
+  fingerprint: prompt.fingerprint ?? null,
+});
+
+const ensurePrompt = (prompt) => {
+  if (!prompt || !Array.isArray(prompt.messages) || prompt.messages.length === 0) {
+    throw new Error('callMoneyBlueprintAI requires a prompt with at least one message.');
+  }
+  return prompt;
+};
+
+const callInvokeLLM = async (prompt) => {
+  const payload = prepareBasePayload(prompt);
+  const response = await InvokeLLM({
+    messages: prompt.messages,
+    metadata: {
+      reportId: payload.reportId,
+      moneyBlueprint: payload,
+    },
+  });
+
+  if (!response || response.ok === false) {
+    const errorMessage = response?.error ?? 'InvokeLLM call failed.';
+    const error = new Error(errorMessage);
+    error.cause = response;
+    throw error;
+  }
+
+  const content = extractAiContent(response) || extractAiContent(response?.data);
+  return { ok: true, provider: 'invoke-llm', content, raw: response };
+};
+
+const parseHttpResponse = async (response) => {
+  const contentType = response.headers?.get?.('content-type') ?? '';
+  if (contentType.includes('application/json')) {
+    try {
+      return await response.json();
+    } catch (error) {
+      return { error, raw: await response.text() };
+    }
+  }
+
+  const text = await response.text();
+  try {
+    return JSON.parse(text);
+  } catch (error) {
+    return { raw: text };
+  }
+};
+
+const callHttpProvider = async (prompt, endpoint, signal) => {
+  const payload = prepareBasePayload(prompt);
+  if (typeof fetch !== 'function') {
+    throw new Error('Global fetch API is not available to call the AI endpoint.');
+  }
+  const response = await fetch(endpoint, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+    signal,
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    const error = new Error(`AI request failed with status ${response.status}`);
+    error.status = response.status;
+    error.body = body;
+    throw error;
+  }
+
+  const data = await parseHttpResponse(response);
+  const content = extractAiContent(data);
+  return { ok: true, provider: 'http', content, raw: data };
+};
+
+export async function callMoneyBlueprintAI(options = {}) {
+  const { prompt: promptPayload, provider, signal, endpoint } = options ?? {};
+  const prompt = ensurePrompt(promptPayload);
+
+  const resolvedProvider = provider ?? DEFAULT_PROVIDER ?? (endpoint || DEFAULT_ENDPOINT ? 'http' : 'invoke-llm');
+
+  if (resolvedProvider === 'invoke-llm' || resolvedProvider === 'base44') {
+    return callInvokeLLM(prompt);
+  }
+
+  const targetEndpoint = pickEndpoint(endpoint);
+  if (!targetEndpoint) {
+    throw new Error('No AI endpoint configured for HTTP provider.');
+  }
+
+  return callHttpProvider(prompt, targetEndpoint, signal);
+}
+

--- a/src/hooks/use-money-blueprint-report.jsx
+++ b/src/hooks/use-money-blueprint-report.jsx
@@ -1,0 +1,181 @@
+import * as React from 'react';
+
+import { callMoneyBlueprintAI } from '@/api/moneyBlueprint';
+import { buildMoneyBlueprintPrompt } from '@/lib/moneyBlueprint/prompt';
+
+const globalCacheStore = new Map();
+
+const defaultCacheKey = (promptPayload) => {
+  if (!promptPayload) return null;
+  if (typeof promptPayload === 'string') return promptPayload;
+  if (promptPayload.reportId) return `report:${promptPayload.reportId}`;
+  if (promptPayload.fingerprint) return promptPayload.fingerprint;
+  return null;
+};
+
+const useIsDev = () => {
+  if (typeof import.meta !== 'undefined' && import.meta.env) {
+    return Boolean(import.meta.env.DEV);
+  }
+  if (typeof process !== 'undefined' && process.env) {
+    return process.env.NODE_ENV === 'development';
+  }
+  return false;
+};
+
+export function useMoneyBlueprintReport(options = {}) {
+  const {
+    provider,
+    endpoint,
+    tone: toneOption,
+    systemInstructions,
+    cache = globalCacheStore,
+    getCacheKey,
+  } = options ?? {};
+
+  const isDev = useIsDev();
+  const cacheRef = React.useRef(cache instanceof Map ? cache : new Map());
+  const [state, setState] = React.useState({ status: 'idle', data: null, error: null });
+  const mountedRef = React.useRef(true);
+
+  React.useEffect(() => () => {
+    mountedRef.current = false;
+  }, []);
+
+  const setStateSafe = React.useCallback((updater) => {
+    if (!mountedRef.current) return;
+    setState((prev) => (typeof updater === 'function' ? updater(prev) : updater));
+  }, []);
+
+  const resolveCacheKey = React.useCallback(
+    (payload) => {
+      if (typeof payload === 'string') return payload;
+
+      if (typeof getCacheKey === 'function') {
+        try {
+          const result = getCacheKey(payload);
+          if (result) return result;
+        } catch (error) {
+          if (isDev && typeof console !== 'undefined') {
+            console.warn('useMoneyBlueprintReport: getCacheKey threw an error', error);
+          }
+        }
+      }
+
+      return defaultCacheKey(payload);
+    },
+    [getCacheKey, isDev]
+  );
+
+  const getCacheStore = React.useCallback(() => {
+    if (!(cacheRef.current instanceof Map)) {
+      cacheRef.current = new Map();
+    }
+    return cacheRef.current;
+  }, []);
+
+  const reset = React.useCallback(() => {
+    setStateSafe({ status: 'idle', data: null, error: null });
+  }, [setStateSafe]);
+
+  const clearCache = React.useCallback(() => {
+    const store = getCacheStore();
+    store.clear();
+  }, [getCacheStore]);
+
+  const removeFromCache = React.useCallback(
+    (identifier) => {
+      const store = getCacheStore();
+      const key = resolveCacheKey(identifier);
+      if (key) {
+        store.delete(key);
+      }
+    },
+    [getCacheStore, resolveCacheKey]
+  );
+
+  const getCachedReport = React.useCallback(
+    (identifier) => {
+      const store = getCacheStore();
+      const key = resolveCacheKey(identifier);
+      if (!key) return null;
+      return store.get(key) ?? null;
+    },
+    [getCacheStore, resolveCacheKey]
+  );
+
+  const hasCachedReport = React.useCallback(
+    (identifier) => getCachedReport(identifier) != null,
+    [getCachedReport]
+  );
+
+  const generateReport = React.useCallback(
+    async ({
+      wizardData,
+      reportId,
+      tone = toneOption,
+      systemInstructions: overrideInstructions,
+      forceRefresh = false,
+      signal,
+    } = {}) => {
+      if (!wizardData) {
+        throw new Error('Wizard data is required to request a Money Blueprint report.');
+      }
+
+      const promptPayload = buildMoneyBlueprintPrompt({
+        wizardData,
+        reportId,
+        tone,
+        systemInstructions: overrideInstructions ?? systemInstructions,
+      });
+
+      const cacheKey = resolveCacheKey(promptPayload);
+      const store = getCacheStore();
+
+      if (!forceRefresh && cacheKey && store.has(cacheKey)) {
+        const cached = store.get(cacheKey);
+        setStateSafe({ status: 'success', data: cached, error: null });
+        return cached;
+      }
+
+      setStateSafe((prev) => ({ status: 'loading', data: forceRefresh ? null : prev.data, error: null }));
+
+      try {
+        const response = await callMoneyBlueprintAI({
+          prompt: promptPayload,
+          provider,
+          endpoint,
+          signal,
+        });
+
+        const payload = { ...response, prompt: promptPayload };
+        if (cacheKey) {
+          store.set(cacheKey, payload);
+        }
+        setStateSafe({ status: 'success', data: payload, error: null });
+        return payload;
+      } catch (error) {
+        setStateSafe((prev) => ({ status: 'error', data: prev.data, error }));
+        throw error;
+      }
+    },
+    [endpoint, getCacheStore, provider, resolveCacheKey, setStateSafe, systemInstructions, toneOption]
+  );
+
+  return {
+    status: state.status,
+    data: state.data,
+    error: state.error,
+    isIdle: state.status === 'idle',
+    isLoading: state.status === 'loading',
+    isSuccess: state.status === 'success',
+    isError: state.status === 'error',
+    generateReport,
+    reset,
+    clearCache,
+    removeFromCache,
+    getCachedReport,
+    hasCachedReport,
+  };
+}
+

--- a/src/lib/moneyBlueprint/insights.js
+++ b/src/lib/moneyBlueprint/insights.js
@@ -1,0 +1,398 @@
+const REGION_LABELS = {
+  england: 'England',
+  scotland: 'Scotland',
+  wales: 'Wales',
+  'northern-ireland': 'Northern Ireland',
+};
+
+const FOCUS_LABELS = {
+  stability: 'Build stability',
+  debt: 'Reduce debt',
+  home: 'Save for a home move',
+  growth: 'Grow savings & investments',
+  'future-proof': 'Prepare for life changes',
+};
+
+const INCOME_FREQUENCY_LABELS = {
+  monthly: 'month',
+  'four-weekly': 'four weeks',
+  fortnightly: 'fortnight',
+  weekly: 'week',
+};
+
+const INCOME_FREQUENCY_TO_MONTHLY = {
+  monthly: 1,
+  'four-weekly': 13 / 12,
+  fortnightly: 26 / 12,
+  weekly: 52 / 12,
+};
+
+const GOAL_AREA_LABELS = {
+  'emergency-fund': 'Build or top up my emergency fund',
+  'clear-debt': 'Pay down expensive debt faster',
+  'home-purchase': 'Save for a home or renovation',
+  retirement: 'Boost retirement contributions',
+  'family-milestones': 'Prepare for family milestones',
+  'upgrade-budgeting': 'Improve budgeting habits',
+};
+
+const TIMELINE_LABELS = {
+  '0-3': '0 – 3 months',
+  '3-6': '3 – 6 months',
+  '6-12': '6 – 12 months',
+  '12+': '12 months or longer',
+};
+
+const BUDGETING_STYLE_LABELS = {
+  detailed: 'Detailed planner',
+  guided: 'Guided tracker',
+  reactive: 'Reactive responder',
+};
+
+const CHECK_IN_LABELS = {
+  weekly: 'Weekly check-ins',
+  fortnightly: 'Every couple of weeks',
+  monthly: 'Once a month',
+  'ad-hoc': 'Only when something changes',
+};
+
+const EMERGENCY_FUND_LABELS = {
+  'less-1': 'Less than 1 month',
+  '1-3': '1 – 3 months',
+  '3-6': '3 – 6 months',
+  '6+': 'More than 6 months',
+};
+
+const CONFIDENCE_LABELS = {
+  'finding-feet': 'Still finding my feet',
+  steady: 'Steady most months',
+  confident: 'Confident and consistent',
+};
+
+const DEFAULT_DATA = {
+  basics: {
+    planName: '',
+    householdSize: '',
+    netIncome: '',
+    incomeFrequency: 'monthly',
+    region: '',
+    focus: '',
+  },
+  priorities: {
+    goalAreas: [],
+    topGoal: '',
+    savingsTarget: '',
+    timeline: '',
+  },
+  habits: {
+    budgetingStyle: '',
+    checkInFrequency: '',
+    emergencyFundMonths: '',
+    confidenceLevel: '',
+    additionalNotes: '',
+  },
+  summary: {
+    shareEmail: '',
+    consentToContact: false,
+  },
+};
+
+const SEVERITY_ORDER = { high: 0, medium: 1, low: 2 };
+
+const clampNumber = (value) => {
+  if (typeof value === 'number') return Number.isFinite(value) ? value : null;
+  if (typeof value === 'string' && value.trim()) {
+    const numeric = Number.parseFloat(value.replace(/,/g, ''));
+    return Number.isFinite(numeric) ? numeric : null;
+  }
+  return null;
+};
+
+const formatCurrency = (value) => {
+  const numeric = clampNumber(value);
+  if (!Number.isFinite(numeric)) return null;
+  try {
+    return new Intl.NumberFormat('en-GB', {
+      style: 'currency',
+      currency: 'GBP',
+      maximumFractionDigits: numeric >= 1000 ? 0 : 2,
+    }).format(numeric);
+  } catch (error) {
+    return `£${numeric.toFixed(numeric >= 1000 ? 0 : 2)}`;
+  }
+};
+
+const normaliseArray = (value) => {
+  if (!Array.isArray(value)) return [];
+  return value.map((item) => (typeof item === 'string' ? item.trim() : '')).filter(Boolean);
+};
+
+const toTitleCase = (value) => {
+  if (typeof value !== 'string' || !value) return '';
+  return value
+    .split(/[-_\s]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+};
+
+export function normaliseMoneyBlueprintData(raw = {}) {
+  const base = JSON.parse(JSON.stringify(DEFAULT_DATA));
+  const safe = typeof raw === 'object' && raw ? raw : {};
+
+  return {
+    basics: { ...base.basics, ...(safe.basics ?? {}) },
+    priorities: {
+      ...base.priorities,
+      ...(safe.priorities ?? {}),
+      goalAreas: normaliseArray(safe?.priorities?.goalAreas),
+    },
+    habits: { ...base.habits, ...(safe.habits ?? {}) },
+    summary: { ...base.summary, ...(safe.summary ?? {}) },
+  };
+}
+
+const listFormatter =
+  typeof Intl !== 'undefined' && typeof Intl.ListFormat === 'function'
+    ? new Intl.ListFormat('en-GB', { style: 'long', type: 'conjunction' })
+    : null;
+
+const joinList = (items) => {
+  const filtered = items.filter(Boolean);
+  if (filtered.length === 0) return '';
+  if (filtered.length === 1) return filtered[0];
+  if (listFormatter) {
+    try {
+      return listFormatter.format(filtered);
+    } catch (error) {
+      // ignore and fall through to manual join
+    }
+  }
+
+  const rest = filtered.slice(0, -1);
+  const last = filtered[filtered.length - 1];
+  return `${rest.join(', ')} and ${last}`;
+};
+
+const computeMonthlyIncome = (netIncome, frequency) => {
+  const numeric = clampNumber(netIncome);
+  if (!Number.isFinite(numeric)) return null;
+  const multiplier = INCOME_FREQUENCY_TO_MONTHLY[frequency] ?? 1;
+  return numeric * multiplier;
+};
+
+const buildHouseholdSummary = (basics) => {
+  const focusLabel = FOCUS_LABELS[basics.focus] ?? (basics.focus ? toTitleCase(basics.focus) : 'Not specified');
+  const regionLabel = REGION_LABELS[basics.region] ?? (basics.region ? toTitleCase(basics.region) : 'Unknown region');
+  const householdSize = clampNumber(basics.householdSize);
+  const householdLabel = householdSize
+    ? `${householdSize} ${householdSize === 1 ? 'person' : 'people'}`
+    : 'an unspecified number of people';
+
+  return `Household of ${householdLabel} in ${regionLabel} focusing on ${focusLabel.toLowerCase()}.`;
+};
+
+const buildIncomeSummary = (basics) => {
+  const netIncome = clampNumber(basics.netIncome);
+  if (!Number.isFinite(netIncome)) return 'Combined take-home pay was not provided.';
+
+  const rawIncome = formatCurrency(netIncome) ?? `${netIncome}`;
+  const frequencyLabel = INCOME_FREQUENCY_LABELS[basics.incomeFrequency] ?? 'month';
+  const monthlyIncome = computeMonthlyIncome(netIncome, basics.incomeFrequency);
+  const monthlyLabel = monthlyIncome ? formatCurrency(monthlyIncome) : null;
+
+  if (monthlyLabel && frequencyLabel !== 'month') {
+    return `Combined take-home pay is about ${rawIncome} each ${frequencyLabel}, which is roughly ${monthlyLabel} per month.`;
+  }
+
+  return `Combined take-home pay is about ${rawIncome} each ${frequencyLabel}.`;
+};
+
+const buildPrioritiesSummary = (priorities) => {
+  const goalLabels = priorities.goalAreas
+    .map((goal) => GOAL_AREA_LABELS[goal] ?? toTitleCase(goal))
+    .filter(Boolean);
+  const headlineGoal = priorities.topGoal?.trim();
+  const timelineLabel = TIMELINE_LABELS[priorities.timeline] ?? '';
+  const savingsTargetLabel = formatCurrency(clampNumber(priorities.savingsTarget));
+
+  const parts = [];
+  if (goalLabels.length) {
+    parts.push(`Key priorities: ${joinList(goalLabels)}.`);
+  }
+  if (headlineGoal) {
+    parts.push(
+      `Headline outcome: ${headlineGoal}${timelineLabel ? ` (${timelineLabel} timeline)` : ''}${
+        savingsTargetLabel ? ` with a savings target of ${savingsTargetLabel}` : ''
+      }.`
+    );
+  } else if (savingsTargetLabel) {
+    parts.push(`Savings target: ${savingsTargetLabel}${timelineLabel ? ` over ${timelineLabel}` : ''}.`);
+  } else if (timelineLabel) {
+    parts.push(`Preferred timeline: ${timelineLabel}.`);
+  }
+
+  return parts.join(' ');
+};
+
+const buildHabitsSummary = (habits) => {
+  const styleLabel = BUDGETING_STYLE_LABELS[habits.budgetingStyle] ?? (habits.budgetingStyle ? toTitleCase(habits.budgetingStyle) : '');
+  const checkInLabel =
+    CHECK_IN_LABELS[habits.checkInFrequency] ??
+    (habits.checkInFrequency ? toTitleCase(habits.checkInFrequency) : '');
+  const emergencyLabel =
+    EMERGENCY_FUND_LABELS[habits.emergencyFundMonths] ??
+    (habits.emergencyFundMonths ? toTitleCase(habits.emergencyFundMonths) : '');
+  const confidenceLabel =
+    CONFIDENCE_LABELS[habits.confidenceLevel] ??
+    (habits.confidenceLevel ? toTitleCase(habits.confidenceLevel) : '');
+
+  const parts = [];
+  if (styleLabel) parts.push(`Budgeting style: ${styleLabel.toLowerCase()}.`);
+  if (checkInLabel) parts.push(`Money reviews: ${checkInLabel.toLowerCase()}.`);
+  if (emergencyLabel) parts.push(`Emergency fund covers ${emergencyLabel.toLowerCase()}.`);
+  if (confidenceLabel) parts.push(`Confidence level: ${confidenceLabel.toLowerCase()}.`);
+
+  return parts.join(' ');
+};
+
+const buildNotesSummary = (habits) => {
+  const notes = habits.additionalNotes?.trim();
+  if (!notes) return '';
+  return `Personal notes: ${notes}`;
+};
+
+const createRiskFlag = (id, severity, title, description, evidence) => ({
+  id,
+  severity,
+  title,
+  description,
+  evidence,
+});
+
+const buildRiskFlags = (data) => {
+  const flags = [];
+  const { basics, priorities, habits } = data;
+
+  if (habits.emergencyFundMonths === 'less-1') {
+    flags.push(
+      createRiskFlag(
+        'emergency-fund-critical',
+        'high',
+        'Emergency fund covers less than one month',
+        'Build a cash buffer that covers at least one month of essential bills to reduce vulnerability to income shocks.',
+        EMERGENCY_FUND_LABELS[habits.emergencyFundMonths] ?? habits.emergencyFundMonths
+      )
+    );
+  } else if (habits.emergencyFundMonths === '1-3') {
+    flags.push(
+      createRiskFlag(
+        'emergency-fund-low',
+        'medium',
+        'Emergency savings below the recommended 3 months',
+        'Increase cash reserves toward the 3–6 month range so the household can absorb unexpected costs.',
+        EMERGENCY_FUND_LABELS[habits.emergencyFundMonths] ?? habits.emergencyFundMonths
+      )
+    );
+  }
+
+  if (habits.checkInFrequency === 'ad-hoc') {
+    flags.push(
+      createRiskFlag(
+        'infrequent-reviews',
+        'medium',
+        'Money reviews only happen when something changes',
+        'Introduce a regular cadence for reviewing the plan to catch overspending early and stay aligned with goals.',
+        CHECK_IN_LABELS[habits.checkInFrequency] ?? habits.checkInFrequency
+      )
+    );
+  }
+
+  if (habits.confidenceLevel === 'finding-feet') {
+    flags.push(
+      createRiskFlag(
+        'low-confidence',
+        'medium',
+        'Confidence about money is low',
+        'Focus on quick wins and accountability routines to build financial confidence.',
+        CONFIDENCE_LABELS[habits.confidenceLevel] ?? habits.confidenceLevel
+      )
+    );
+  }
+
+  const netIncome = clampNumber(basics.netIncome);
+  if (!Number.isFinite(netIncome)) {
+    flags.push(
+      createRiskFlag(
+        'missing-income',
+        'low',
+        'Household income was not provided',
+        'Capture the combined take-home pay to benchmark savings rates and debt affordability.',
+        null
+      )
+    );
+  }
+
+  if (priorities.goalAreas.includes('clear-debt') && !priorities.savingsTarget?.trim()) {
+    flags.push(
+      createRiskFlag(
+        'debt-without-target',
+        'low',
+        'Debt reduction goal lacks a repayment target',
+        'Estimate the total balance or a repayment milestone so progress can be measured.',
+        'Goal area: clear debt'
+      )
+    );
+  }
+
+  return flags.sort((a, b) => SEVERITY_ORDER[a.severity] - SEVERITY_ORDER[b.severity]);
+};
+
+export function createMoneyBlueprintInsights(rawData) {
+  const data = normaliseMoneyBlueprintData(rawData);
+
+  const summaryBullets = [];
+  summaryBullets.push(buildHouseholdSummary(data.basics));
+  summaryBullets.push(buildIncomeSummary(data.basics));
+
+  const prioritiesSummary = buildPrioritiesSummary(data.priorities);
+  if (prioritiesSummary) {
+    summaryBullets.push(prioritiesSummary);
+  }
+
+  const habitsSummary = buildHabitsSummary(data.habits);
+  if (habitsSummary) {
+    summaryBullets.push(habitsSummary);
+  }
+
+  const notesSummary = buildNotesSummary(data.habits);
+  if (notesSummary) {
+    summaryBullets.push(notesSummary);
+  }
+
+  const riskFlags = buildRiskFlags(data);
+
+  return {
+    summaryBullets,
+    riskFlags,
+    metadata: {
+      focus: FOCUS_LABELS[data.basics.focus] ?? data.basics.focus ?? '',
+      region: REGION_LABELS[data.basics.region] ?? data.basics.region ?? '',
+      householdSize: clampNumber(data.basics.householdSize),
+      monthlyNetIncome: computeMonthlyIncome(data.basics.netIncome, data.basics.incomeFrequency),
+      goalAreas: data.priorities.goalAreas,
+    },
+    raw: data,
+  };
+}
+
+export function createMoneyBlueprintRiskSummary(rawData) {
+  const { riskFlags } = createMoneyBlueprintInsights(rawData);
+  return riskFlags;
+}
+
+export function createMoneyBlueprintSummary(rawData) {
+  const { summaryBullets } = createMoneyBlueprintInsights(rawData);
+  return summaryBullets;
+}
+

--- a/src/lib/moneyBlueprint/prompt.js
+++ b/src/lib/moneyBlueprint/prompt.js
@@ -1,0 +1,124 @@
+import { createMoneyBlueprintInsights, normaliseMoneyBlueprintData } from './insights';
+
+export const MONEY_BLUEPRINT_DISCLAIMER =
+  'This summary is educational and not financial advice. Speak to a regulated financial adviser for personalised guidance.';
+
+const DEFAULT_TONE = 'supportive and practical';
+
+const buildSystemPrompt = (tone = DEFAULT_TONE, extraInstructions = []) => {
+  const lines = [
+    'You are the Money Blueprint assistant for Calculate My Money.',
+    `Your tone should remain ${tone}, using UK English and positive, action-focused language.`,
+    'Do not provide regulated financial advice, make product recommendations, or mention specific providers.',
+    'Base all observations on the supplied household information, summary bullet points, and risk flags.',
+    `Always finish with the exact disclaimer: "${MONEY_BLUEPRINT_DISCLAIMER}"`,
+    'Use concise paragraphs and bullet points so the reader can skim key actions quickly.',
+  ];
+
+  if (Array.isArray(extraInstructions) && extraInstructions.length) {
+    lines.push(...extraInstructions);
+  }
+
+  return lines.join('\n');
+};
+
+const sanitiseData = (rawData) => {
+  const data = normaliseMoneyBlueprintData(rawData);
+  return {
+    basics: {
+      planName: data.basics.planName?.trim() ?? '',
+      householdSize: data.basics.householdSize ?? '',
+      netIncome: data.basics.netIncome ?? '',
+      incomeFrequency: data.basics.incomeFrequency ?? '',
+      region: data.basics.region ?? '',
+      focus: data.basics.focus ?? '',
+    },
+    priorities: {
+      goalAreas: data.priorities.goalAreas ?? [],
+      topGoal: data.priorities.topGoal?.trim() ?? '',
+      savingsTarget: data.priorities.savingsTarget ?? '',
+      timeline: data.priorities.timeline ?? '',
+    },
+    habits: {
+      budgetingStyle: data.habits.budgetingStyle ?? '',
+      checkInFrequency: data.habits.checkInFrequency ?? '',
+      emergencyFundMonths: data.habits.emergencyFundMonths ?? '',
+      confidenceLevel: data.habits.confidenceLevel ?? '',
+      additionalNotes: data.habits.additionalNotes?.trim() ?? '',
+    },
+    summary: {
+      consentToContact: Boolean(data.summary.consentToContact),
+      providedEmail: Boolean(data.summary.shareEmail),
+    },
+  };
+};
+
+const formatSummaryBullets = (bullets) => {
+  if (!Array.isArray(bullets) || bullets.length === 0) return '- None available';
+  return bullets.map((bullet) => `- ${bullet}`).join('\n');
+};
+
+const formatRiskFlags = (flags) => {
+  if (!Array.isArray(flags) || flags.length === 0) return '- No specific risks detected in the answers.';
+
+  return flags
+    .map((flag) => {
+      const evidence = flag.evidence ? ` (Evidence: ${flag.evidence})` : '';
+      return `- [${flag.severity.toUpperCase()}] ${flag.title}: ${flag.description}${evidence}`;
+    })
+    .join('\n');
+};
+
+const buildUserPrompt = ({ reportId, summaryBullets, riskFlags, data }) => {
+  const sections = [
+    `Report reference: ${reportId ?? 'Not assigned'}`,
+    'Wizard responses (PII removed):',
+    JSON.stringify(data, null, 2),
+    'Derived summary bullet points:',
+    formatSummaryBullets(summaryBullets),
+    'Risk considerations highlighted by the formatter:',
+    formatRiskFlags(riskFlags),
+    'Please craft a Money Blueprint report that includes the following sections in order: \n1. Snapshot \n2. Opportunities \n3. Watch-outs \n4. Suggested next moves \n5. Disclaimer',
+    'In the Watch-outs section, address each risk flag if any are provided. If there are no risks, reassure the user to continue routine reviews.',
+    'Refer to the report by the anonymised ID when it helps reinforce accountability.',
+  ];
+
+  return sections.join('\n\n');
+};
+
+const createFingerprint = (reportId, data, summaryBullets, riskFlags) =>
+  JSON.stringify({
+    reportId: reportId ?? null,
+    data,
+    summaryBullets,
+    riskFlags: Array.isArray(riskFlags)
+      ? riskFlags.map((flag) => ({ id: flag.id, severity: flag.severity }))
+      : [],
+  });
+
+export function buildMoneyBlueprintPrompt(options = {}) {
+  const { wizardData, reportId, tone = DEFAULT_TONE, systemInstructions } = options ?? {};
+
+  const insights = createMoneyBlueprintInsights(wizardData);
+  const sanitisedData = sanitiseData(insights.raw);
+  const summaryBullets = insights.summaryBullets ?? [];
+  const riskFlags = insights.riskFlags ?? [];
+  const fingerprint = createFingerprint(reportId, sanitisedData, summaryBullets, riskFlags);
+
+  const systemMessage = buildSystemPrompt(tone, systemInstructions);
+  const userMessage = buildUserPrompt({ reportId, summaryBullets, riskFlags, data: sanitisedData });
+
+  return {
+    reportId: reportId ?? null,
+    messages: [
+      { role: 'system', content: systemMessage },
+      { role: 'user', content: userMessage },
+    ],
+    summaryBullets,
+    riskFlags,
+    sanitisedData,
+    disclaimer: MONEY_BLUEPRINT_DISCLAIMER,
+    fingerprint,
+  };
+}
+


### PR DESCRIPTION
## Summary
- add a formatter that derives Money Blueprint summary bullets and risk flags from wizard responses
- introduce a prompt builder that packages anonymised inputs, derived insights, and disclaimer instructions for AI providers
- create an AI client and hook that invoke the selected provider, manage loading/error state, and cache Money Blueprint reports

## Testing
- npm run lint *(fails: missing @eslint/js in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fa4d6fcf6c8320b2c047e4025a71e4