### PR TITLE
Add privacy disclaimers and clearing controls to Money Blueprint wizard

### DIFF
--- a/src/components/alerts/PrivacyAssuranceBanner.jsx
+++ b/src/components/alerts/PrivacyAssuranceBanner.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { ShieldCheck } from 'lucide-react';
+
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { cn } from '@/lib/utils';
+
+export function PrivacyAssuranceBanner({
+  className,
+  title = 'Your answers stay private',
+  description = 'We never store your Money Blueprint responses on our servers. Everything stays on this device unless you choose to export or share it.',
+  icon: Icon = ShieldCheck,
+  children,
+}) {
+  return (
+    <Alert
+      className={cn(
+        'border-primary/60 bg-primary/5 text-primary dark:border-primary/50 dark:bg-primary/10',
+        className
+      )}
+    >
+      {Icon ? <Icon aria-hidden="true" className="h-5 w-5 text-primary" /> : null}
+      <div className="space-y-2">
+        {title ? (
+          <AlertTitle className="text-sm font-semibold text-primary">{title}</AlertTitle>
+        ) : null}
+        {(description || children) && (
+          <AlertDescription className="space-y-2 text-sm leading-relaxed text-primary/90 dark:text-primary/80">
+            {description ? <p>{description}</p> : null}
+            {children}
+          </AlertDescription>
+        )}
+      </div>
+    </Alert>
+  );
+}
+
+export default PrivacyAssuranceBanner;

--- a/src/components/alerts/index.js
+++ b/src/components/alerts/index.js
@@ -1,0 +1,1 @@
+export * from './PrivacyAssuranceBanner.jsx';

--- a/src/hooks/use-money-blueprint-wizard.jsx
+++ b/src/hooks/use-money-blueprint-wizard.jsx
@@ -197,6 +197,33 @@ export function useMoneyBlueprintWizard(options = {}) {
     [status]
   );
 
+  const clearStepData = React.useCallback(
+    (stepId) => {
+      if (!stepId) return;
+
+      setData((prev) => {
+        const base = getInitialData();
+        const next = { ...(prev ?? {}) };
+        next[stepId] = cloneData(base?.[stepId] ?? {});
+        return next;
+      });
+
+      if (status === 'completed') {
+        setStatus('collecting');
+        setCompletedAt(null);
+      }
+    },
+    [getInitialData, status]
+  );
+
+  const clearAllData = React.useCallback(() => {
+    setData(getInitialData());
+    if (status === 'completed') {
+      setStatus('collecting');
+      setCompletedAt(null);
+    }
+  }, [getInitialData, status]);
+
   const goToStep = React.useCallback(
     (index) => {
       if (typeof index !== 'number' || Number.isNaN(index)) return;
@@ -261,6 +288,8 @@ export function useMoneyBlueprintWizard(options = {}) {
     completedAt,
     reportId,
     updateStepData,
+    clearStepData,
+    clearAllData,
     goToStep,
     nextStep,
     previousStep,


### PR DESCRIPTION
## Summary
- add a reusable PrivacyAssuranceBanner component for privacy messaging across the app
- surface stronger privacy and professional-advice disclaimers on the Money Blueprint intro and final report steps, and expose a clear-step action in navigation
- extend the Money Blueprint wizard hook with clear helpers so answers can be wiped mid-session

## Testing
- npm run lint *(fails: missing @eslint/js module in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fa550a622083208d3197d8e58ff891