### PR TITLE
Add Money Blueprint unit tests and update supporting utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,15 @@ npm run dev
 npm run build
 ```
 
+## Testing
+
+```bash
+npm test
+```
+
+The test suite relies on Node's built-in test runner and focuses on the Money
+Blueprint data validation, AI prompt construction, and export utilities.
+
 ## UK Financial Stats data sources
 
 The `/api/uk-financial-stats` endpoint aggregates publicly available statistics from:
@@ -40,3 +49,10 @@ by setting the `SITE_URL` environment variable when invoking the script (e.g.
 `SITE_URL=https://staging.calcmymoney.co.uk npm run sitemap`).
 
 For more information and support, please contact Base44 support at app@base44.com.
+
+## Money Blueprint export & AI dependencies
+
+Money Blueprint PDF and CSV exports are powered by [`pdf-lib`](https://github.com/Hopding/pdf-lib),
+while AI summarisation requests are sent through the [`@base44/sdk`](https://www.npmjs.com/package/@base44/sdk).
+Ensure these dependencies remain available in deployment environments so the
+report generation workflow works end-to-end.

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
+    "test": "node --test \"src/__tests__/**/*.test.js\"",
     "gen:images": "sharp ./logo-high-res.webp --width 32 --output public/logo-32.webp --format webp && sharp ./logo-high-res.webp --width 64 --output public/logo-64.webp --format webp && sharp ./logo-high-res.webp --width 128 --output public/logo-128.webp --format webp && sharp ./logo-high-res.webp --width 64 --output public/logo-64.avif --format avif && sharp ./logo-high-res.webp --width 16 --output public/favicon-16x16.png --format png && sharp ./logo-high-res.webp --width 32 --output public/favicon-32x32.png --format png && sharp ./logo-high-res.webp --width 180 --output public/apple-touch-icon.png --format png && sharp ./logo-high-res.webp --width 192 --output public/icon-192.png --format png && sharp ./logo-high-res.webp --width 512 --output public/icon-512.png --format png"
   },
   "dependencies": {

--- a/src/__tests__/moneyBlueprintPrompt.test.js
+++ b/src/__tests__/moneyBlueprintPrompt.test.js
@@ -1,0 +1,118 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+
+import {
+  buildMoneyBlueprintPrompt,
+  MONEY_BLUEPRINT_DISCLAIMER,
+} from '../lib/moneyBlueprint/prompt.js';
+
+const baseWizardData = {
+  basics: {
+    planName: '  Growth focus  ',
+    householdSize: '3',
+    netIncome: '2,500.00',
+    incomeFrequency: 'four-weekly',
+    region: 'scotland',
+    focus: 'stability',
+  },
+  priorities: {
+    goalAreas: ['clear-debt', 'emergency-fund', ''],
+    topGoal: '  Clear the credit card balance  ',
+    savingsTarget: '1200',
+    timeline: '3-6',
+  },
+  habits: {
+    budgetingStyle: 'guided',
+    checkInFrequency: 'ad-hoc',
+    emergencyFundMonths: 'less-1',
+    confidenceLevel: 'finding-feet',
+    additionalNotes: '  Keep encouraging monthly reviews.  ',
+  },
+  summary: {
+    shareEmail: '',
+    consentToContact: false,
+  },
+};
+
+const cloneWizardData = () => JSON.parse(JSON.stringify(baseWizardData));
+
+describe('buildMoneyBlueprintPrompt', () => {
+  test('builds a full prompt with sanitised data and fingerprint', () => {
+    const prompt = buildMoneyBlueprintPrompt({
+      wizardData: cloneWizardData(),
+      reportId: 'ABCD1234',
+    });
+
+    assert.equal(prompt.reportId, 'ABCD1234');
+    assert.equal(prompt.disclaimer, MONEY_BLUEPRINT_DISCLAIMER);
+    assert.equal(prompt.messages.length, 2);
+    assert.equal(prompt.messages[0].role, 'system');
+    assert.ok(prompt.messages[0].content.includes('supportive and practical'));
+    assert.ok(prompt.messages[1].content.includes('Report reference: ABCD1234'));
+
+    assert.deepEqual(prompt.sanitisedData, {
+      basics: {
+        planName: 'Growth focus',
+        householdSize: '3',
+        netIncome: '2,500.00',
+        incomeFrequency: 'four-weekly',
+        region: 'scotland',
+        focus: 'stability',
+      },
+      priorities: {
+        goalAreas: ['clear-debt', 'emergency-fund'],
+        topGoal: 'Clear the credit card balance',
+        savingsTarget: '1200',
+        timeline: '3-6',
+      },
+      habits: {
+        budgetingStyle: 'guided',
+        checkInFrequency: 'ad-hoc',
+        emergencyFundMonths: 'less-1',
+        confidenceLevel: 'finding-feet',
+        additionalNotes: 'Keep encouraging monthly reviews.',
+      },
+      summary: {
+        consentToContact: false,
+        providedEmail: false,
+      },
+    });
+
+    const riskIds = prompt.riskFlags.map((flag) => flag.id);
+    assert.deepEqual(riskIds, [
+      'emergency-fund-critical',
+      'infrequent-reviews',
+      'low-confidence',
+    ]);
+
+    assert.ok(
+      prompt.summaryBullets.some((bullet) =>
+        bullet.includes('Household of 3 people in Scotland focusing on build stability.')
+      )
+    );
+    assert.ok(
+      prompt.summaryBullets.some((bullet) =>
+        bullet.includes('Combined take-home pay is about £2,500 each four weeks')
+      )
+    );
+
+    const fingerprint = JSON.parse(prompt.fingerprint);
+    assert.deepEqual(fingerprint, {
+      reportId: 'ABCD1234',
+      data: prompt.sanitisedData,
+      summaryBullets: prompt.summaryBullets,
+      riskFlags: prompt.riskFlags.map(({ id, severity }) => ({ id, severity })),
+    });
+  });
+
+  test('applies custom tone and additional system instructions', () => {
+    const prompt = buildMoneyBlueprintPrompt({
+      wizardData: cloneWizardData(),
+      tone: 'calm and clear',
+      systemInstructions: ['Include scenario planning ideas.'],
+    });
+
+    assert.ok(prompt.messages[0].content.includes('calm and clear'));
+    assert.ok(prompt.messages[0].content.includes('Include scenario planning ideas.'));
+  });
+});

--- a/src/__tests__/moneyBlueprintReport.test.js
+++ b/src/__tests__/moneyBlueprintReport.test.js
@@ -1,0 +1,139 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+
+import {
+  buildMoneyBlueprintDataset,
+  buildMoneyBlueprintCsvRows,
+  generateMoneyBlueprintCsv,
+  formatBlueprintReportId,
+} from '../lib/moneyBlueprint/report.js';
+
+const baseReport = {
+  reportId: 'ABCD1234EFGH',
+  status: 'completed',
+  completedAt: '2024-04-15T08:30:00Z',
+  basics: {
+    planName: 'Sky High',
+    householdSize: '4',
+    netIncome: '£2,500.50',
+    incomeFrequency: 'four-weekly',
+    region: 'wales',
+    focus: 'growth',
+  },
+  priorities: {
+    goalAreas: ['clear-debt', 'upgrade-budgeting'],
+    topGoal: 'Reduce credit card balances',
+    savingsTarget: '1500',
+    timeline: '6-12',
+  },
+  habits: {
+    budgetingStyle: 'detailed',
+    checkInFrequency: 'monthly',
+    emergencyFundMonths: '1-3',
+    confidenceLevel: 'steady',
+    additionalNotes: 'Review new budgeting apps each quarter.',
+  },
+  summary: {
+    shareEmail: 'team@example.com',
+    consentToContact: true,
+  },
+};
+
+const withReportClone = () => JSON.parse(JSON.stringify(baseReport));
+
+const expectCloseTo = (actual, expected, tolerance = 0.0001) => {
+  const difference = Math.abs(actual - expected);
+  assert.ok(
+    difference <= tolerance,
+    `Expected ${actual} to be within ${tolerance} of ${expected} (difference ${difference})`
+  );
+};
+
+describe('formatBlueprintReportId', () => {
+  test('splits identifiers into blocks of four characters', () => {
+    assert.equal(formatBlueprintReportId('ABCD123456'), 'ABCD 1234 56');
+    assert.equal(formatBlueprintReportId(''), '');
+    assert.equal(formatBlueprintReportId(null), '');
+  });
+});
+
+describe('buildMoneyBlueprintDataset', () => {
+  test('derives household metadata and income calculations', () => {
+    const generatedAt = '2024-05-01T12:00:00Z';
+    const dataset = buildMoneyBlueprintDataset(withReportClone(), { generatedAt });
+
+    assert.equal(dataset.meta.reportId, 'ABCD1234EFGH');
+    assert.equal(dataset.meta.formattedReportId, 'ABCD 1234 EFGH');
+    assert.equal(dataset.meta.status, 'completed');
+    assert.equal(dataset.basics.planName, 'Sky High');
+    assert.equal(dataset.meta.householdSize, '4');
+    assert.equal(dataset.meta.frequencyLabel, 'Every 4 weeks');
+    assert.equal(dataset.meta.regionLabel, 'Wales');
+    assert.equal(dataset.meta.focusLabel, 'Grow savings & investments');
+
+    assert.equal(dataset.meta.goalCount, 2);
+    assert.deepEqual(dataset.meta.goalLabels, [
+      'Pay down expensive debt faster',
+      'Improve budgeting habits',
+    ]);
+
+    assert.equal(dataset.meta.budgetingStyle, 'Detailed planner');
+    assert.equal(
+      dataset.meta.budgetingStyleDescription,
+      'I use a spreadsheet or app to plan every pound.'
+    );
+    assert.equal(dataset.meta.shareEmail, 'team@example.com');
+    assert.equal(dataset.meta.consent, true);
+
+    assert.equal(dataset.priorities.topGoal, 'Reduce credit card balances');
+    assert.equal(dataset.priorities.timeline, '6-12');
+    assert.equal(dataset.habits.additionalNotes, 'Review new budgeting apps each quarter.');
+
+    assert.equal(dataset.meta.netIncomeValue, 2500.5);
+    assert.ok(Number.isFinite(dataset.meta.annualIncome));
+    assert.ok(Number.isFinite(dataset.meta.monthlyIncome));
+    expectCloseTo(dataset.meta.annualIncome, 2500.5 * 13);
+    expectCloseTo(dataset.meta.monthlyIncome, (2500.5 * 13) / 12);
+
+    assert.ok(dataset.meta.generatedAt instanceof Date);
+    assert.ok(dataset.meta.generatedAtLabel.includes('2024'));
+  });
+});
+
+describe('buildMoneyBlueprintCsvRows', () => {
+  test('summarises the dataset into labelled rows', () => {
+    const rows = buildMoneyBlueprintCsvRows(withReportClone(), {
+      generatedAt: '2024-05-01T12:00:00Z',
+    });
+
+    assert.deepEqual(rows[0], ['Section', 'Field', 'Value']);
+
+    const statusRow = rows.find((row) => row[1] === 'Status');
+    assert.equal(statusRow[2], 'Completed');
+
+    const goalRow = rows.find((row) => row[1] === 'Goal areas');
+    assert.equal(goalRow[2], 'Pay down expensive debt faster; Improve budgeting habits');
+
+    const consentRow = rows.find((row) => row[1] === 'Reminder consent');
+    assert.equal(consentRow[2], 'Yes');
+  });
+});
+
+describe('generateMoneyBlueprintCsv', () => {
+  test('returns a CSV string, rows and browser-friendly blob', () => {
+    const result = generateMoneyBlueprintCsv(withReportClone(), {
+      generatedAt: '2024-05-01T12:00:00Z',
+    });
+
+    assert.ok(result.csv.startsWith('"Section","Field","Value"'));
+    assert.ok(Array.isArray(result.rows));
+    assert.ok(result.rows.length > 5);
+
+    if (typeof Blob === 'undefined') {
+      assert.equal(result.blob, null);
+    } else {
+      assert.ok(result.blob instanceof Blob);
+      assert.ok(result.blob.size > 0);
+    }
+  });
+});

--- a/src/__tests__/moneyBlueprintSchema.test.js
+++ b/src/__tests__/moneyBlueprintSchema.test.js
@@ -1,0 +1,92 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+
+import {
+  validateMoneyBlueprintStep,
+  validateMoneyBlueprint,
+} from '../lib/moneyBlueprint/schema.js';
+
+const validBasics = {
+  planName: 'Spring refresh',
+  householdSize: '3',
+  netIncome: '2500.50',
+  incomeFrequency: 'monthly',
+  region: 'england',
+  focus: 'growth',
+};
+
+const validPriorities = {
+  goalAreas: ['clear-debt', 'emergency-fund'],
+  topGoal: 'Pay off the credit card in full',
+  savingsTarget: '1500',
+  timeline: '6-12',
+};
+
+const validHabits = {
+  budgetingStyle: 'guided',
+  checkInFrequency: 'monthly',
+  emergencyFundMonths: '3-6',
+  confidenceLevel: 'steady',
+  additionalNotes: 'Focus on meal planning to lower food costs.',
+};
+
+const validSummary = {
+  shareEmail: 'user@example.com',
+  consentToContact: true,
+};
+
+describe('validateMoneyBlueprintStep', () => {
+  test('returns success for valid basics data', () => {
+    const result = validateMoneyBlueprintStep('basics', validBasics);
+    assert.equal(result.success, true);
+    assert.deepEqual(result.errors, {});
+  });
+
+  test('collects validation errors for invalid numeric values', () => {
+    const result = validateMoneyBlueprintStep('basics', {
+      ...validBasics,
+      netIncome: 'abc',
+    });
+
+    assert.equal(result.success, false);
+    assert.equal(
+      result.errors.netIncome,
+      'Use numbers only, you can include up to 2 decimal places.'
+    );
+    assert.ok(Array.isArray(result.issues));
+    assert.ok(result.issues.length > 0);
+  });
+
+  test('requires an email when consent is granted', () => {
+    const result = validateMoneyBlueprintStep('summary', {
+      shareEmail: '',
+      consentToContact: true,
+    });
+
+    assert.equal(result.success, false);
+    assert.equal(result.errors.shareEmail, 'Add your email so we can send the reminder.');
+  });
+
+  test('treats unknown steps as already valid', () => {
+    const result = validateMoneyBlueprintStep('unknown-step', { foo: 'bar' });
+
+    assert.equal(result.success, true);
+    assert.deepEqual(result.errors, {});
+    assert.deepEqual(result.issues, []);
+  });
+});
+
+describe('validateMoneyBlueprint', () => {
+  test('accepts a complete and valid submission', () => {
+    const result = validateMoneyBlueprint({
+      basics: validBasics,
+      priorities: validPriorities,
+      habits: validHabits,
+      summary: validSummary,
+    });
+
+    assert.equal(result.success, true);
+    assert.deepEqual(result.data.basics, validBasics);
+    assert.deepEqual(result.data.summary, validSummary);
+  });
+});

--- a/src/lib/moneyBlueprint/prompt.js
+++ b/src/lib/moneyBlueprint/prompt.js
@@ -1,4 +1,4 @@
-import { createMoneyBlueprintInsights, normaliseMoneyBlueprintData } from './insights';
+import { createMoneyBlueprintInsights, normaliseMoneyBlueprintData } from './insights.js';
 
 export const MONEY_BLUEPRINT_DISCLAIMER =
   'This summary is educational and not financial advice. Speak to a regulated financial adviser for personalised guidance.';

--- a/src/lib/moneyBlueprint/report.js
+++ b/src/lib/moneyBlueprint/report.js
@@ -1,5 +1,19 @@
-import { PDFDocument, StandardFonts, rgb } from 'pdf-lib';
-import { MONEY_BLUEPRINT_DEFAULT_DATA } from '@/hooks/use-money-blueprint-wizard';
+let cachedPdfLib;
+
+async function loadPdfLib() {
+  if (cachedPdfLib) {
+    return cachedPdfLib;
+  }
+
+  const module = await import('pdf-lib');
+  cachedPdfLib = {
+    PDFDocument: module.PDFDocument,
+    StandardFonts: module.StandardFonts,
+    rgb: module.rgb,
+  };
+
+  return cachedPdfLib;
+}
 
 const INCOME_FREQUENCY_LABELS = {
   monthly: 'Monthly',
@@ -81,7 +95,7 @@ const EMERGENCY_FUND_LABELS = {
   '6+': 'More than 6 months',
 };
 
-const DEFAULT_DATA = MONEY_BLUEPRINT_DEFAULT_DATA || {
+const DEFAULT_DATA = {
   basics: {
     planName: '',
     householdSize: '',
@@ -294,6 +308,7 @@ function createPageContext(pdfDoc, pageSize = BASE_PAGE_SIZE) {
 
 export async function generateMoneyBlueprintPdf(report = {}, options = {}) {
   const dataset = buildMoneyBlueprintDataset(report, options);
+  const { PDFDocument, StandardFonts, rgb } = await loadPdfLib();
   const pdfDoc = await PDFDocument.create();
   const regularFont = await pdfDoc.embedFont(StandardFonts.Helvetica);
   const boldFont = await pdfDoc.embedFont(StandardFonts.HelveticaBold);


### PR DESCRIPTION
## Summary
- replace the Money Blueprint validation helpers with framework-agnostic logic so they can run in Node tests
- add unit coverage for schema validation, AI prompt construction, and report export utilities
- document the new test workflow and call out PDF/AI dependencies for deployments

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68fa57cfdef08320bec5b9b14633cf0a