### PR TITLE
Fix Money Blueprint exports and add navigation link

### DIFF
--- a/src/pages/Layout.jsx
+++ b/src/pages/Layout.jsx
@@ -572,14 +572,15 @@ export default function Layout({ children, currentPageName }) {
     }
   }, [currentPageName]);
 
-  const mainNavLinks = [
-    { name: 'All Calculators', url: createPageUrl('home') },
-    { name: 'Job Salaries', url: createPageUrl('job-salaries') },
-    { name: 'Cost of Living', url: createPageUrl('cost-of-living') },
-    { name: 'Financial Stats', url: createPageUrl('uk-financial-stats') },
-    { name: 'Blog', url: createPageUrl('blog') },
-    { name: 'Resources', url: createPageUrl('resources') },
-  ];
+    const mainNavLinks = [
+      { name: 'All Calculators', url: createPageUrl('home') },
+      { name: 'Job Salaries', url: createPageUrl('job-salaries') },
+      { name: 'Cost of Living', url: createPageUrl('cost-of-living') },
+      { name: 'Financial Stats', url: createPageUrl('uk-financial-stats') },
+      { name: 'My Money Blueprint', url: createPageUrl('my-money-blueprint') },
+      { name: 'Blog', url: createPageUrl('blog') },
+      { name: 'Resources', url: createPageUrl('resources') },
+    ];
 
   const isActiveLink = useCallback(
     (url) => {


### PR DESCRIPTION
## Summary
- rebuild the client-side Money Blueprint report generator to produce clean PDF and CSV exports without invalid syntax
- enhance the generated report copy with educational disclaimers and structured sections for household, priorities, habits, and reminders
- add the My Money Blueprint wizard to the primary navigation so it is easy to reach from the header

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f95d2a35bc8320a183ef3674bf3f56