### PR TITLE
Fix currency converter page crash

### DIFF
--- a/src/pages/calculators/currency-converter.jsx
+++ b/src/pages/calculators/currency-converter.jsx
@@ -10,6 +10,7 @@ import ExportActions from '@/components/calculators/ExportActions';
 import RelatedCalculators from '@/components/calculators/RelatedCalculators';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
 import { Button } from '@/components/ui/button';
 import {
   Select,


### PR DESCRIPTION
## Summary
- add the missing Label import so the currency converter form renders properly

## Testing
- npm run lint *(fails: Cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68fa6f3b305483208a29a08060fd49d1