### PR TITLE
Remove currency converter link from catalog and sitemap

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -193,10 +193,6 @@
     <lastmod>2025-10-22T21:19:42.001Z</lastmod>
   </url>
   <url>
-    <loc>https://www.calcmymoney.co.uk/currency-converter</loc>
-    <lastmod>2025-10-22T21:19:42.001Z</lastmod>
-  </url>
-  <url>
     <loc>https://www.calcmymoney.co.uk/debt-calculator</loc>
     <lastmod>2025-10-22T21:19:42.001Z</lastmod>
   </url>

--- a/scripts/build-calculator-data.mjs
+++ b/scripts/build-calculator-data.mjs
@@ -104,7 +104,6 @@ const manualCategoryAssignments = {
   'energy-bill-calculator': 'utilities-tools',
   'fuel-cost-calculator': 'utilities-tools',
   'price-per-unit-calculator': 'utilities-tools',
-  'currency-converter': 'utilities-tools',
   'tip-calculator': 'utilities-tools',
   'emergency-fund-calculator': 'budgeting-planning',
   'net-worth-calculator': 'budgeting-planning',

--- a/src/components/data/calculatorCatalog.generated.js
+++ b/src/components/data/calculatorCatalog.generated.js
@@ -1188,15 +1188,6 @@ export const generatedCalculatorCatalog = [
     "description": "Handy everyday calculators for bills, conversions, and splitting shared household costs.",
     "calculators": [
       {
-        "slug": "currency-converter",
-        "name": "Currency Converter Calculator",
-        "description": "Convert currencies using mid-market exchange rates. Enter an amount and see the converted value for popular GBP pairs.",
-        "url": "/currency-converter",
-        "page": "calculators/currency-converter",
-        "keywords": [],
-        "status": "active"
-      },
-      {
         "slug": "energy-bill-calculator",
         "name": "Energy Bill Calculator",
         "description": "Estimate monthly and annual UK energy bills by combining electricity and gas usage, standing charges, VAT, and smoothing buffers.",

--- a/src/pages/calculators/currency-converter.jsx
+++ b/src/pages/calculators/currency-converter.jsx
@@ -10,6 +10,7 @@ import ExportActions from '@/components/calculators/ExportActions';
 import RelatedCalculators from '@/components/calculators/RelatedCalculators';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
 import { Button } from '@/components/ui/button';
 import {
   Select,


### PR DESCRIPTION
## Summary
- remove the currency converter entry from the generated calculator catalog so it no longer appears in home page search and category listings
- delete the currency converter URL from the published sitemap.xml
- update the calculator data build script to keep the entry from being regenerated

## Testing
- npm run lint *(fails: Cannot find module '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68fa6f3b305483208a29a08060fd49d1