### PR TITLE
Restore home page calculator directory and trim index heading

### DIFF
--- a/src/components/general/CalculatorIndex.jsx
+++ b/src/components/general/CalculatorIndex.jsx
@@ -10,14 +10,9 @@ export default function CalculatorIndex() {
         <details className="group">
           <summary className="cursor-pointer list-none">
             <div className="flex items-center justify-between bg-gray-50 hover:bg-gray-100 border border-gray-200 rounded-lg p-4 transition-colors">
-              <div>
-                <h2 className="text-lg md:text-xl font-semibold text-gray-900">
-                  Browse all calculators (A–Z by category)
-                </h2>
-                <p className="text-sm text-gray-600">
-                  Open this index to quickly jump to any tool across the site.
-                </p>
-              </div>
+              <p className="text-sm text-gray-600">
+                Open this index to quickly jump to any tool across the site.
+              </p>
               <span className="text-blue-600 text-sm font-medium">Show/Hide</span>
             </div>
           </summary>


### PR DESCRIPTION
## Summary
- revert the previous removal of the calculator directory so the home page category cards trigger the directory view again
- drop the "Browse all calculators (A–Z by category)" heading from the collapsed calculator index section

## Testing
- npm run lint *(fails: Cannot find module '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68fa77efa2708320acc68c83065efa3c