### PR TITLE
Remove home page category hub cards

### DIFF
--- a/src/components/general/CalculatorIndex.jsx
+++ b/src/components/general/CalculatorIndex.jsx
@@ -10,14 +10,9 @@ export default function CalculatorIndex() {
         <details className="group">
           <summary className="cursor-pointer list-none">
             <div className="flex items-center justify-between bg-gray-50 hover:bg-gray-100 border border-gray-200 rounded-lg p-4 transition-colors">
-              <div>
-                <h2 className="text-lg md:text-xl font-semibold text-gray-900">
-                  Browse all calculators (A–Z by category)
-                </h2>
-                <p className="text-sm text-gray-600">
-                  Open this index to quickly jump to any tool across the site.
-                </p>
-              </div>
+              <p className="text-sm text-gray-600">
+                Open this index to quickly jump to any tool across the site.
+              </p>
               <span className="text-blue-600 text-sm font-medium">Show/Hide</span>
             </div>
           </summary>

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -87,35 +87,11 @@ export default function Home() {
     setSearchQuery(e.target.value);
   };
 
-  const fallbackHubCards = useMemo(
-    () =>
-      DEFAULT_DIRECTORY_CATEGORIES.map((category) => {
-        const Icon = getCategoryIcon(category.slug) || Calculator;
-        return {
-          title: category.name,
-          icon: Icon,
-          link: `#${category.slug}`,
-          description: category.description,
-        };
-      }),
-    []
-  );
-
   const directoryCategories = useMemo(() => {
     if (!calcData.categories.length) return DEFAULT_DIRECTORY_CATEGORIES;
     const map = new Map(calcData.categories.map((category) => [category.slug, category]));
     return DEFAULT_DIRECTORY_CATEGORIES.map((category) => map.get(category.slug) || category);
   }, [calcData.categories]);
-
-  const hubCards = useMemo(() => {
-    if (!calcData.categories.length) return fallbackHubCards;
-    return directoryCategories.map((category) => ({
-      title: category.name,
-      icon: getCategoryIcon(category.slug) || Calculator,
-      link: `#${category.slug}`,
-      description: category.description,
-    }));
-  }, [calcData.categories, directoryCategories, fallbackHubCards]);
 
   useEffect(() => {
     const origin =
@@ -289,39 +265,6 @@ export default function Home() {
               )}
             </div>
           </div>
-        </div>
-      </div>
-
-      {/* Hub Cards Section */}
-      <div className="relative z-10 -mt-16 max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
-        <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-6">
-          {hubCards.map((card, index) => (
-            <button
-              key={index}
-              type="button"
-              onClick={(event) => {
-                event.preventDefault();
-                const slug = card.link.startsWith('#') ? card.link.slice(1) : card.link;
-                setPendingScrollSlug(slug);
-                setShowAllCalculators(true);
-              }}
-              className="group block w-full transform rounded-lg border border-card-muted bg-card p-6 text-left shadow-md transition-all duration-300 hover:-translate-y-1 hover:border-primary/40 hover:shadow-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60"
-            >
-              <div className="flex items-center gap-4 mb-2">
-                <div className="rounded-full bg-pill p-3 text-pill-foreground">
-                  <card.icon className="h-6 w-6" />
-                </div>
-                <Heading
-                  as="h3"
-                  size="h3"
-                  className="text-foreground transition-colors group-hover:text-primary"
-                >
-                  {card.title}
-                </Heading>
-              </div>
-              <p className="body text-muted-foreground">{card.description}</p>
-            </button>
-          ))}
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- remove the home page category hub cards and associated logic so the hero flows directly into the calculator directory
- keep the calculator directory accessible via the existing show/hide control

## Testing
- npm run lint *(fails: Cannot find module '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68fa77efa2708320acc68c83065efa3c