### PR TITLE
Hide calculator index link on home page

### DIFF
--- a/src/components/general/CalculatorIndex.jsx
+++ b/src/components/general/CalculatorIndex.jsx
@@ -1,9 +1,18 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import { calculatorCategories } from '../data/calculatorConfig.js';
 import { createPageUrl } from '@/utils';
 
 export default function CalculatorIndex() {
+  const location = useLocation();
+  const pathname = location?.pathname ?? '/';
+  const normalizedPath = pathname.replace(/\/+$/, '') || '/';
+  const isHomePage = normalizedPath === '/';
+
+  if (isHomePage) {
+    return null;
+  }
+
   return (
     <section className="bg-white border-t border-gray-200 non-printable">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-10">


### PR DESCRIPTION
## Summary
- prevent the calculator index component from rendering when the current route is the home page so the “Browse all calculators (A–Z by category)” link no longer appears there

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68faa35cd12083209a46b0d95a052738