### PR TITLE
Fix property flipping calculator route reference

### DIFF
--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -376,7 +376,7 @@ function PagesContent() {
           <Route path="/present-value-calculator" element={<LazyPresentValueCalculator />} />
           <Route path="/price-per-unit-calculator" element={<LazyPricePerUnitCalculator />} />
           <Route path="/pro-rata-salary-calculator" element={<LazyProRataSalaryCalculator />} />
-          <Route path="/property-flipping-calculator" element={<LazyPropertyFppingCalculator />} />
+          <Route path="/property-flipping-calculator" element={<LazyPropertyFlippingCalculator />} />
           <Route path="/property-tax-calculator" element={<LazyPropertyTaxCalculator />} />
           <Route path="/rent-to-buy-calculator" element={<LazyRentToBuyCalculator />} />
           <Route path="/rent-vs-buy-calculator" element={<LazyRentVsBuyCalculator />} />


### PR DESCRIPTION
## Summary
- correct the property flipping calculator route to render the proper lazy component

## Testing
- PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1 npm install *(fails: sharp dependency download blocked by proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6903f20108c083209e7838ca7270a7f6