### PR TITLE
Handle empty currency inputs as zero

### DIFF
--- a/src/components/form/CurrencyInput.jsx
+++ b/src/components/form/CurrencyInput.jsx
@@ -53,15 +53,24 @@ const CurrencyInput = ({
 
         const handleChange = (event) => {
           const normalised = normaliseInput(event.target.value);
-          setDisplayValue(normalised ? formatter.format(Number(normalised)) : '');
+          if (!normalised) {
+            setDisplayValue('');
+            onChange('');
+            return;
+          }
+          setDisplayValue(formatter.format(Number(normalised)));
           onChange(normalised);
         };
 
         const handleBlur = (event) => {
           const normalised = normaliseInput(event.target.value);
+          const resolvedValue = normalised === '' ? '0' : normalised;
           setDisplayValue(
-            normalised ? formatNumber(normalised, minimumFractionDigits, maximumFractionDigits) : ''
+            resolvedValue
+              ? formatNumber(resolvedValue, minimumFractionDigits, maximumFractionDigits)
+              : ''
           );
+          onChange(resolvedValue);
           onBlur();
         };
 


### PR DESCRIPTION
## Summary
- normalise empty currency inputs to zero on blur so validation can proceed during the blueprint survey
- avoid formatting blank values while typing to keep the field responsive

## Testing
- not run (local environment could not install npm dependencies)

------
https://chatgpt.com/codex/tasks/task_e_690938e32e4c8320ad271fcf68e8aabd