### PR TITLE
Fix property flipping calculator route component typo

### DIFF
--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -377,7 +377,7 @@ function PagesContent() {
           <Route path="/present-value-calculator" element={<LazyPresentValueCalculator />} />
           <Route path="/price-per-unit-calculator" element={<LazyPricePerUnitCalculator />} />
           <Route path="/pro-rata-salary-calculator" element={<LazyProRataSalaryCalculator />} />
-          <Route path="/property-flipping-calculator" element={<LazyPropertyFppingCalculator />} />
+          <Route path="/property-flipping-calculator" element={<LazyPropertyFlippingCalculator />} />
           <Route path="/property-tax-calculator" element={<LazyPropertyTaxCalculator />} />
           <Route path="/rent-to-buy-calculator" element={<LazyRentToBuyCalculator />} />
           <Route path="/rent-vs-buy-calculator" element={<LazyRentVsBuyCalculator />} />


### PR DESCRIPTION
## Summary
- correct the property flipping calculator route to use the properly named lazy component so it renders without throwing a runtime error

## Testing
- npm install *(fails: puppeteer cannot download Chromium in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_690b9fee40708320860efd7386f875f6