### PR TITLE
Enhance report sections for expanded blueprint payload

### DIFF
--- a/src/pages/financial-blueprint/ReportDisplay.jsx
+++ b/src/pages/financial-blueprint/ReportDisplay.jsx
@@ -3,8 +3,7 @@
 import React from 'react';
 import ProfileSummary from './report-components/ProfileSummary';
 import FinancialOverview from './report-components/FinancialOverview';
-import CashFlowAnalysis from './report-components/CashFlowAnalysis';
-import TaxAnalysis from './report-components/TaxAnalysis';
+import TaxAndCashflow from './report-components/TaxAndCashflow';
 import RetirementSnapshot from './report-components/RetirementSnapshot';
 import ProtectionReview from './report-components/ProtectionReview';
 import SwotAnalysis from './report-components/SwotAnalysis';
@@ -23,6 +22,7 @@ const ReportDisplay = ({ reportData }) => {
   const {
     profileSummary,
     financialOverview,
+    taxAndCashflow,
     cashFlowAnalysis,
     taxAnalysis,
     retirementSnapshot,
@@ -43,8 +43,7 @@ const ReportDisplay = ({ reportData }) => {
         {/* We pass the relevant piece of data to each component */}
         <ProfileSummary data={profileSummary} />
         <FinancialOverview data={financialOverview} />
-        <CashFlowAnalysis data={cashFlowAnalysis} />
-        <TaxAnalysis data={taxAnalysis} />
+        <TaxAndCashflow data={taxAndCashflow || (taxAnalysis || cashFlowAnalysis ? { tax: taxAnalysis, cashflow: cashFlowAnalysis } : null)} />
         <RetirementSnapshot data={retirementSnapshot} />
         <ProtectionReview data={protectionReview} />
         <SwotAnalysis data={swotAnalysis} />

--- a/src/pages/financial-blueprint/report-components/ProfileSummary.jsx
+++ b/src/pages/financial-blueprint/report-components/ProfileSummary.jsx
@@ -1,65 +1,250 @@
 // src/pages/financial-blueprint/report-components/ProfileSummary.jsx
 import React from 'react';
+import ReportSection from './ReportSection';
+
+const formatLabel = (label) => {
+  if (!label) return '';
+  const cleaned = label.replace(/_/g, ' ').replace(/([A-Z])/g, ' $1');
+  return cleaned.charAt(0).toUpperCase() + cleaned.slice(1);
+};
+
+const normaliseMembers = (data) => {
+  if (!data) return [];
+
+  if (Array.isArray(data.members)) {
+    return data.members;
+  }
+  if (Array.isArray(data.household?.members)) {
+    return data.household.members;
+  }
+  if (Array.isArray(data.clients)) {
+    return data.clients;
+  }
+
+  const entries = [];
+  if (data.primaryClient) {
+    entries.push({ relationship: 'You', ...data.primaryClient });
+  }
+  if (data.partner) {
+    entries.push({ relationship: 'Partner', ...data.partner });
+  }
+  if (Array.isArray(data.dependants)) {
+    data.dependants.forEach((dependant) => entries.push({ relationship: 'Dependant', ...dependant }));
+  }
+  return entries;
+};
+
+const normaliseEmployment = (employment) => {
+  if (!employment) return [];
+
+  if (Array.isArray(employment)) {
+    return employment;
+  }
+  if (Array.isArray(employment.roles)) {
+    return employment.roles;
+  }
+  if (Array.isArray(employment.members)) {
+    return employment.members;
+  }
+
+  if (typeof employment === 'string') {
+    return [{ summary: employment }];
+  }
+
+  return Object.entries(employment)
+    .map(([key, value]) => {
+      if (!value) return null;
+      if (typeof value === 'string') {
+        return { label: formatLabel(key), summary: value };
+      }
+      return { label: formatLabel(key), ...value };
+    })
+    .filter(Boolean);
+};
+
+const normaliseHealthIndicators = (health) => {
+  if (!health) return [];
+
+  if (Array.isArray(health)) {
+    return health;
+  }
+
+  if (typeof health === 'string') {
+    return [health];
+  }
+
+  return Object.entries(health)
+    .map(([key, value]) => ({ label: formatLabel(key), value }))
+    .filter((item) => item.value !== undefined && item.value !== null && item.value !== '');
+};
 
 const ProfileSummary = ({ data }) => {
-  if (!data) return null;
+  if (!data) {
+    return (
+      <ReportSection title="Profile Summary">
+        <p className="text-sm text-gray-500">We&apos;re gathering your household details. Check back in a moment.</p>
+      </ReportSection>
+    );
+  }
 
-  const { userCode, headline, household, dependants, employment, location, incomeOverview, priorities } = data;
+  const {
+    userCode,
+    household,
+    householdMakeup,
+    location,
+    headline,
+    dependants,
+    healthIndicators,
+  } = data;
+
+  const members = normaliseMembers(data);
+  const employmentEntries = normaliseEmployment(data.employment);
+  const healthEntries = normaliseHealthIndicators(healthIndicators || data.health);
+
+  const householdFacts = [
+    {
+      label: 'Household Makeup',
+      value: householdMakeup || household?.description || household?.composition || household,
+    },
+    {
+      label: 'Location',
+      value: location || household?.location,
+    },
+    {
+      label: 'Dependants',
+      value: Array.isArray(dependants) ? dependants.length : dependants,
+    },
+  ].filter((item) => item.value !== undefined && item.value !== null && item.value !== '');
 
   return (
-    <section className="bg-white shadow-md rounded-lg p-6 space-y-4">
-      <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-2">
-        <h2 className="text-xl font-semibold text-gray-800">Profile Summary</h2>
-        {userCode ? <span className="text-sm font-mono text-gray-500">Reference: {userCode}</span> : null}
+    <ReportSection
+      title="Profile Summary"
+      action={userCode ? <span className="font-mono text-xs uppercase tracking-wide">Ref: {userCode}</span> : null}
+    >
+      {headline ? <p className="text-sm text-gray-600">{headline}</p> : null}
+
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
+        <div className="lg:col-span-2 space-y-4">
+          <div>
+            <h3 className="text-sm font-semibold text-gray-700">Household Members</h3>
+            {members.length > 0 ? (
+              <div className="mt-3 grid grid-cols-1 gap-3 sm:grid-cols-2">
+                {members.map((member, index) => (
+                  <div key={index} className="rounded-xl border border-gray-100 bg-gray-50 p-4">
+                    <p className="text-base font-semibold text-gray-900">
+                      {member.name || member.fullName || member.label || `Member ${index + 1}`}
+                    </p>
+                    <dl className="mt-2 space-y-1 text-sm">
+                      {member.relationship ? (
+                        <div className="flex justify-between text-gray-600">
+                          <dt>Relationship</dt>
+                          <dd className="font-medium text-gray-900">{member.relationship}</dd>
+                        </div>
+                      ) : null}
+                      {member.age ? (
+                        <div className="flex justify-between text-gray-600">
+                          <dt>Age</dt>
+                          <dd className="font-medium text-gray-900">{member.age}</dd>
+                        </div>
+                      ) : null}
+                      {member.lifeStage ? (
+                        <div className="flex justify-between text-gray-600">
+                          <dt>Life stage</dt>
+                          <dd className="font-medium text-gray-900">{member.lifeStage}</dd>
+                        </div>
+                      ) : null}
+                      {member.notes ? (
+                        <p className="text-xs text-gray-500">{member.notes}</p>
+                      ) : null}
+                    </dl>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <p className="mt-2 text-sm text-gray-500">No household members recorded yet.</p>
+            )}
+          </div>
+
+          <div>
+            <h3 className="text-sm font-semibold text-gray-700">Employment</h3>
+            {employmentEntries.length > 0 ? (
+              <div className="mt-3 space-y-3">
+                {employmentEntries.map((entry, index) => (
+                  <div key={index} className="rounded-xl border border-gray-100 bg-white p-4 shadow-sm">
+                    <p className="text-sm font-semibold text-gray-900">
+                      {entry.label || entry.name || `Role ${index + 1}`}
+                    </p>
+                    <dl className="mt-2 space-y-1 text-sm text-gray-600">
+                      {entry.summary ? <dd className="text-gray-600">{entry.summary}</dd> : null}
+                      {entry.status ? (
+                        <div className="flex justify-between">
+                          <dt>Status</dt>
+                          <dd className="font-medium text-gray-900">{entry.status}</dd>
+                        </div>
+                      ) : null}
+                      {entry.employer ? (
+                        <div className="flex justify-between">
+                          <dt>Employer</dt>
+                          <dd className="font-medium text-gray-900">{entry.employer}</dd>
+                        </div>
+                      ) : null}
+                      {entry.income ? (
+                        <div className="flex justify-between">
+                          <dt>Income</dt>
+                          <dd className="font-medium text-gray-900">{entry.income}</dd>
+                        </div>
+                      ) : null}
+                    </dl>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <p className="mt-2 text-sm text-gray-500">Employment information will appear once provided.</p>
+            )}
+          </div>
+        </div>
+
+        <div className="space-y-6">
+          <div>
+            <h3 className="text-sm font-semibold text-gray-700">Household At-a-glance</h3>
+            {householdFacts.length > 0 ? (
+              <dl className="mt-3 space-y-3 text-sm">
+                {householdFacts.map((fact, index) => (
+                  <div key={index} className="rounded-lg border border-gray-100 bg-gray-50 p-3">
+                    <dt className="text-gray-500">{fact.label}</dt>
+                    <dd className="font-medium text-gray-900">{fact.value}</dd>
+                  </div>
+                ))}
+              </dl>
+            ) : (
+              <p className="mt-2 text-sm text-gray-500">We&apos;ll highlight key household facts here.</p>
+            )}
+          </div>
+
+          <div>
+            <h3 className="text-sm font-semibold text-gray-700">Health Indicators</h3>
+            {healthEntries.length > 0 ? (
+              <ul className="mt-3 space-y-2 text-sm text-gray-600">
+                {healthEntries.map((item, index) => (
+                  <li key={index} className="rounded-lg border border-emerald-100 bg-emerald-50 p-3 text-emerald-900">
+                    {item.label ? (
+                      <div className="flex justify-between">
+                        <span className="font-medium">{item.label}</span>
+                        <span>{item.value}</span>
+                      </div>
+                    ) : (
+                      <span>{item.value || item}</span>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <p className="mt-2 text-sm text-gray-500">Let us know about any health considerations.</p>
+            )}
+          </div>
+        </div>
       </div>
-
-      {headline ? <p className="text-gray-700 text-sm">{headline}</p> : null}
-
-      <dl className="grid grid-cols-1 sm:grid-cols-2 gap-4 text-sm">
-        {household ? (
-          <div>
-            <dt className="font-medium text-gray-600">Household</dt>
-            <dd className="text-gray-900">{household}</dd>
-          </div>
-        ) : null}
-        {dependants ? (
-          <div>
-            <dt className="font-medium text-gray-600">Dependants</dt>
-            <dd className="text-gray-900">{dependants}</dd>
-          </div>
-        ) : null}
-        {employment ? (
-          <div>
-            <dt className="font-medium text-gray-600">Employment</dt>
-            <dd className="text-gray-900">{employment}</dd>
-          </div>
-        ) : null}
-        {location ? (
-          <div>
-            <dt className="font-medium text-gray-600">Location</dt>
-            <dd className="text-gray-900">{location}</dd>
-          </div>
-        ) : null}
-      </dl>
-
-      {incomeOverview ? (
-        <div className="rounded-lg border bg-gray-50 p-4">
-          <h3 className="text-sm font-semibold text-gray-700 mb-2">Income Overview</h3>
-          <p className="text-sm text-gray-600">{incomeOverview}</p>
-        </div>
-      ) : null}
-
-      {Array.isArray(priorities) && priorities.length > 0 ? (
-        <div>
-          <h3 className="text-sm font-semibold text-gray-700">Top Priorities</h3>
-          <ul className="mt-2 space-y-1 list-disc list-inside text-sm text-gray-600">
-            {priorities.map((item, index) => (
-              <li key={index}>{item}</li>
-            ))}
-          </ul>
-        </div>
-      ) : null}
-    </section>
+    </ReportSection>
   );
 };
 

--- a/src/pages/financial-blueprint/report-components/ProtectionReview.jsx
+++ b/src/pages/financial-blueprint/report-components/ProtectionReview.jsx
@@ -1,67 +1,75 @@
 // src/pages/financial-blueprint/report-components/ProtectionReview.jsx
 import React from 'react';
+import ReportSection from './ReportSection';
+
+const formatStatus = (value) => {
+  if (value === null || value === undefined || value === '') {
+    return 'Not recorded';
+  }
+  return value === 'yes' || value === true ? 'In place' : 'Not in place';
+};
 
 const ProtectionReview = ({ data }) => {
-  if (!data) return null;
+  if (!data) {
+    return (
+      <ReportSection title="Protection Review">
+        <p className="text-sm text-gray-500">Protection recommendations will appear once your answers are processed.</p>
+      </ReportSection>
+    );
+  }
 
   const { coverageOverview, existingCover, gaps, priorities } = data;
 
-  const formatStatus = (value) => (value === 'yes' || value === true ? 'In place' : 'Not in place');
+  const hasExistingCover = existingCover && Object.keys(existingCover).length > 0;
+  const hasGaps = Array.isArray(gaps) && gaps.length > 0;
+  const hasPriorities = Array.isArray(priorities) && priorities.length > 0;
 
   return (
-    <section className="space-y-4">
-      <h2 className="text-xl font-semibold text-gray-800">Financial Protection Review</h2>
-      <div className="rounded-lg bg-white shadow p-6 space-y-4">
-        <p className="text-gray-700 text-sm">{coverageOverview}</p>
+    <ReportSection title="Protection Review" subtitle="Assess your safety net and identify any gaps">
+      {coverageOverview ? <p className="text-sm text-gray-600">{coverageOverview}</p> : null}
 
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm">
-          <div className="rounded-lg border bg-gray-50 p-4">
-            <h3 className="font-semibold text-gray-800 mb-3">Existing Cover</h3>
-            <dl className="space-y-2">
-              <div className="flex justify-between">
-                <dt className="text-gray-500">Will</dt>
-                <dd className="font-medium text-gray-900">{formatStatus(existingCover?.hasWill)}</dd>
-              </div>
-              <div className="flex justify-between">
-                <dt className="text-gray-500">Life Insurance</dt>
-                <dd className="font-medium text-gray-900">{formatStatus(existingCover?.hasLifeInsurance)}</dd>
-              </div>
-              <div className="flex justify-between">
-                <dt className="text-gray-500">Income Protection</dt>
-                <dd className="font-medium text-gray-900">{formatStatus(existingCover?.hasIncomeProtection)}</dd>
-              </div>
-              <div className="flex justify-between">
-                <dt className="text-gray-500">Lasting Power of Attorney</dt>
-                <dd className="font-medium text-gray-900">{formatStatus(existingCover?.hasLPA)}</dd>
-              </div>
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        <div className="rounded-xl border border-gray-100 bg-gray-50 p-4">
+          <h3 className="text-sm font-semibold text-gray-700">Existing Cover</h3>
+          {hasExistingCover ? (
+            <dl className="mt-3 space-y-2 text-sm">
+              {Object.entries(existingCover).map(([key, value]) => (
+                <div key={key} className="flex items-center justify-between">
+                  <dt className="text-gray-500">{key.replace(/([A-Z])/g, ' $1').replace(/^./, (char) => char.toUpperCase())}</dt>
+                  <dd className="font-medium text-gray-900">{formatStatus(value)}</dd>
+                </div>
+              ))}
             </dl>
-          </div>
-          <div className="rounded-lg border bg-gray-50 p-4">
-            <h3 className="font-semibold text-gray-800 mb-3">Protection Gaps</h3>
-            {Array.isArray(gaps) && gaps.length > 0 ? (
-              <ul className="space-y-1 list-disc list-inside text-gray-600">
-                {gaps.map((gap, index) => (
-                  <li key={index}>{gap}</li>
-                ))}
-              </ul>
-            ) : (
-              <p className="text-gray-500">No major gaps identified.</p>
-            )}
-          </div>
+          ) : (
+            <p className="mt-2 text-sm text-gray-500">Let us know what cover you already have in place.</p>
+          )}
         </div>
 
-        {Array.isArray(priorities) && priorities.length > 0 ? (
-          <div>
-            <h3 className="text-sm font-semibold text-gray-700">Priority Actions</h3>
-            <ul className="mt-2 space-y-1 list-disc list-inside text-sm text-gray-600">
-              {priorities.map((item, index) => (
-                <li key={index}>{item}</li>
+        <div className="rounded-xl border border-amber-100 bg-amber-50 p-4 text-amber-900">
+          <h3 className="text-sm font-semibold">Protection Gaps</h3>
+          {hasGaps ? (
+            <ul className="mt-2 space-y-1 list-disc list-inside text-sm">
+              {gaps.map((gap, index) => (
+                <li key={index}>{gap}</li>
               ))}
             </ul>
-          </div>
-        ) : null}
+          ) : (
+            <p className="mt-2 text-sm">No major gaps identified from the current information.</p>
+          )}
+        </div>
       </div>
-    </section>
+
+      {hasPriorities ? (
+        <div className="rounded-xl border border-indigo-100 bg-indigo-50 p-4 text-indigo-900">
+          <h3 className="text-sm font-semibold">Priority Actions</h3>
+          <ul className="mt-2 space-y-1 list-disc list-inside text-sm">
+            {priorities.map((item, index) => (
+              <li key={index}>{item}</li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+    </ReportSection>
   );
 };
 

--- a/src/pages/financial-blueprint/report-components/ReportSection.jsx
+++ b/src/pages/financial-blueprint/report-components/ReportSection.jsx
@@ -1,0 +1,30 @@
+// src/pages/financial-blueprint/report-components/ReportSection.jsx
+import React from 'react';
+
+const joinClassNames = (...classes) => classes.filter(Boolean).join(' ');
+
+const ReportSection = ({
+  title,
+  subtitle,
+  action,
+  children,
+  className,
+  cardClassName = 'p-6 space-y-4',
+}) => {
+  return (
+    <section className={joinClassNames('space-y-4', className)}>
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h2 className="text-xl font-semibold text-gray-900">{title}</h2>
+          {subtitle ? <p className="text-sm text-gray-500">{subtitle}</p> : null}
+        </div>
+        {action ? <div className="text-sm font-medium text-gray-500">{action}</div> : null}
+      </div>
+      <div className="rounded-2xl border border-gray-200 bg-white shadow-sm">
+        <div className={cardClassName}>{children}</div>
+      </div>
+    </section>
+  );
+};
+
+export default ReportSection;

--- a/src/pages/financial-blueprint/report-components/RetirementSnapshot.jsx
+++ b/src/pages/financial-blueprint/report-components/RetirementSnapshot.jsx
@@ -1,5 +1,6 @@
 // src/pages/financial-blueprint/report-components/RetirementSnapshot.jsx
 import React from 'react';
+import ReportSection from './ReportSection';
 
 const currencyFormatter = new Intl.NumberFormat('en-GB', {
   style: 'currency',
@@ -8,14 +9,20 @@ const currencyFormatter = new Intl.NumberFormat('en-GB', {
 });
 
 const formatCurrency = (value) => {
-  if (value === null || value === undefined) {
+  if (value === null || value === undefined || value === '') {
     return '£0';
   }
   return currencyFormatter.format(Number(value));
 };
 
 const RetirementSnapshot = ({ data }) => {
-  if (!data) return null;
+  if (!data) {
+    return (
+      <ReportSection title="Retirement Snapshot">
+        <p className="text-sm text-gray-500">We&apos;ll calculate your retirement outlook once the data is ready.</p>
+      </ReportSection>
+    );
+  }
 
   const {
     readinessSummary,
@@ -27,55 +34,61 @@ const RetirementSnapshot = ({ data }) => {
     partner,
   } = data;
 
-  return (
-    <section className="space-y-4">
-      <h2 className="text-xl font-semibold text-gray-800">Retirement Readiness</h2>
-      <div className="rounded-lg bg-white shadow p-6 space-y-4">
-        <p className="text-gray-700 text-sm">{readinessSummary}</p>
+  const hasHeadlineFigures =
+    yearsToRetirement !== undefined || projectedPensionPot !== undefined || sustainableAnnualDrawdown !== undefined;
 
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-4 text-sm">
-          <div className="rounded-lg border p-4 bg-gray-50">
-            <h3 className="text-gray-700 font-semibold">Years to Retirement</h3>
-            <p className="text-2xl font-bold text-gray-900">{Number(yearsToRetirement ?? 0).toFixed(0)}</p>
+  return (
+    <ReportSection title="Retirement Snapshot" subtitle="A quick view of your readiness for life after work">
+      {readinessSummary ? <p className="text-sm text-gray-600">{readinessSummary}</p> : null}
+
+      {hasHeadlineFigures ? (
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+          <div className="rounded-xl border border-gray-100 bg-gray-50 p-4">
+            <h3 className="text-sm font-semibold text-gray-700">Years to Retirement</h3>
+            <p className="text-2xl font-bold text-gray-900">
+              {yearsToRetirement !== undefined ? Number(yearsToRetirement).toFixed(0) : '–'}
+            </p>
             {partner?.yearsToRetirement !== undefined ? (
-              <p className="text-xs text-gray-500 mt-1">
-                Partner retirement horizon: {Number(partner.yearsToRetirement ?? 0).toFixed(0)} years
+              <p className="mt-1 text-xs text-gray-500">
+                Partner timeline: {Number(partner.yearsToRetirement).toFixed(0)} years
               </p>
             ) : null}
           </div>
-          <div className="rounded-lg border p-4 bg-gray-50">
-            <h3 className="text-gray-700 font-semibold">Projected Pension Pot</h3>
+          <div className="rounded-xl border border-gray-100 bg-gray-50 p-4">
+            <h3 className="text-sm font-semibold text-gray-700">Projected Pension Pot</h3>
             <p className="text-2xl font-bold text-gray-900">{formatCurrency(projectedPensionPot)}</p>
           </div>
-          <div className="rounded-lg border p-4 bg-gray-50">
-            <h3 className="text-gray-700 font-semibold">Sustainable Drawdown</h3>
+          <div className="rounded-xl border border-gray-100 bg-gray-50 p-4">
+            <h3 className="text-sm font-semibold text-gray-700">Sustainable Drawdown</h3>
             <p className="text-2xl font-bold text-gray-900">{formatCurrency(sustainableAnnualDrawdown)}</p>
           </div>
         </div>
+      ) : (
+        <p className="text-sm text-gray-500">We&apos;ll display your projected pension figures here when available.</p>
+      )}
 
-        {Array.isArray(assumptions) && assumptions.length > 0 ? (
-          <div>
-            <h3 className="text-sm font-semibold text-gray-700">Key Assumptions</h3>
-            <ul className="mt-2 space-y-1 text-sm text-gray-600 list-disc list-inside">
-              {assumptions.map((item, index) => (
-                <li key={index}>{item}</li>
-              ))}
-            </ul>
-          </div>
-        ) : null}
+      {Array.isArray(assumptions) && assumptions.length > 0 ? (
+        <div className="rounded-xl border border-gray-100 bg-white p-4 shadow-sm">
+          <h3 className="text-sm font-semibold text-gray-700">Key Assumptions</h3>
+          <ul className="mt-2 space-y-1 list-inside list-disc text-sm text-gray-600">
+            {assumptions.map((item, index) => (
+              <li key={index}>{item}</li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
 
-        {Array.isArray(nextSteps) && nextSteps.length > 0 ? (
-          <div>
-            <h3 className="text-sm font-semibold text-gray-700">Next Steps</h3>
-            <ul className="mt-2 space-y-1 text-sm text-gray-600 list-disc list-inside">
-              {nextSteps.map((item, index) => (
-                <li key={index}>{item}</li>
-              ))}
-            </ul>
-          </div>
-        ) : null}
-      </div>
-    </section>
+      {Array.isArray(nextSteps) && nextSteps.length > 0 ? (
+        <div className="rounded-xl border border-indigo-100 bg-indigo-50 p-4 text-indigo-900">
+          <h3 className="text-sm font-semibold">Suggested Next Steps</h3>
+          <ul className="mt-2 space-y-1 list-disc list-inside text-sm">
+            {nextSteps.map((item, index) => (
+              <li key={index}>{item}</li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+    </ReportSection>
   );
 };
 

--- a/src/pages/financial-blueprint/report-components/TaxAndCashflow.jsx
+++ b/src/pages/financial-blueprint/report-components/TaxAndCashflow.jsx
@@ -1,0 +1,201 @@
+// src/pages/financial-blueprint/report-components/TaxAndCashflow.jsx
+import React from 'react';
+import ReportSection from './ReportSection';
+
+const currencyFormatter = new Intl.NumberFormat('en-GB', {
+  style: 'currency',
+  currency: 'GBP',
+  maximumFractionDigits: 0,
+});
+
+const percentageFormatter = new Intl.NumberFormat('en-GB', {
+  style: 'percent',
+  minimumFractionDigits: 1,
+  maximumFractionDigits: 1,
+});
+
+const formatCurrency = (value) => {
+  if (value === null || value === undefined || value === '') {
+    return '£0';
+  }
+  const numericValue = Number(value);
+  if (Number.isNaN(numericValue)) {
+    return value;
+  }
+  return currencyFormatter.format(numericValue);
+};
+
+const formatPercent = (value) => {
+  if (value === null || value === undefined || value === '') {
+    return '0%';
+  }
+  const numericValue = Number(value);
+  if (Number.isNaN(numericValue)) {
+    return value;
+  }
+  return percentageFormatter.format(numericValue);
+};
+
+const formatLabel = (label) => {
+  if (!label) return '';
+  return label
+    .toString()
+    .replace(/_/g, ' ')
+    .replace(/([A-Z])/g, ' $1')
+    .replace(/^./, (char) => char.toUpperCase())
+    .trim();
+};
+
+const KeyFigure = ({ label, value, helper, variant = 'default' }) => {
+  const background =
+    variant === 'highlight'
+      ? 'bg-indigo-50 border-indigo-100 text-indigo-900'
+      : 'bg-gray-50 border-gray-100 text-gray-900';
+  return (
+    <div className={`rounded-xl border p-4 ${background}`}>
+      <p className="text-xs font-semibold uppercase tracking-wide text-gray-500">{label}</p>
+      <p className="mt-2 text-2xl font-bold">{value}</p>
+      {helper ? <p className="mt-1 text-xs text-gray-500">{helper}</p> : null}
+    </div>
+  );
+};
+
+const BreakdownList = ({ title, entries, formatter = formatCurrency }) => {
+  if (!entries) return null;
+  const entryArray = Array.isArray(entries)
+    ? entries
+    : Object.entries(entries).map(([key, value]) => ({ label: formatLabel(key), value }));
+
+  if (entryArray.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="rounded-xl border border-gray-100 bg-white p-4 shadow-sm">
+      <h3 className="text-sm font-semibold text-gray-700">{title}</h3>
+      <dl className="mt-3 space-y-2 text-sm text-gray-600">
+        {entryArray.map((entry, index) => (
+          <div key={`${entry.label || entry.name || index}-${index}`} className="flex justify-between">
+            <dt>{entry.label || entry.name || formatLabel(entry.key)}</dt>
+            <dd className="font-medium text-gray-900">{formatter(entry.value)}</dd>
+          </div>
+        ))}
+      </dl>
+    </div>
+  );
+};
+
+const TaxAndCashflow = ({ data }) => {
+  const taxData =
+    data?.tax ||
+    data?.taxation ||
+    data?.taxAnalysis ||
+    data?.taxSummary ||
+    data?.taxInsights ||
+    null;
+  const cashflowData =
+    data?.cashflow ||
+    data?.cashFlow ||
+    data?.cashFlowAnalysis ||
+    data?.cashflowSummary ||
+    data?.cashflowInsights ||
+    null;
+
+  const hasContent = taxData || cashflowData;
+
+  if (!hasContent) {
+    return (
+      <ReportSection title="Tax & Cashflow Overview">
+        <p className="text-sm text-gray-500">We&apos;ll surface tax and cashflow insights here once they&apos;re available.</p>
+      </ReportSection>
+    );
+  }
+
+  const combinedSummary = data?.summary || taxData?.summary || cashflowData?.summary;
+  const disposableIncome = cashflowData?.disposableIncome || data?.disposableIncome;
+
+  return (
+    <ReportSection title="Tax & Cashflow Overview" subtitle="Understand how money flows through your household each year">
+      {combinedSummary ? <p className="text-sm text-gray-600">{combinedSummary}</p> : null}
+
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
+        <KeyFigure
+          label="Gross Annual Income"
+          value={formatCurrency(cashflowData?.incomeSummary?.grossAnnualIncome)}
+          helper={cashflowData?.incomeSummary?.commentary}
+        />
+        <KeyFigure
+          label="Total Annual Expenses"
+          value={formatCurrency(cashflowData?.expenseSummary?.annualTotal)}
+          helper={cashflowData?.expenseSummary?.commentary}
+        />
+        <KeyFigure
+          label="Estimated Tax Liability"
+          value={formatCurrency(taxData?.figures?.totalTax || taxData?.totalTax)}
+          helper={taxData?.summary}
+          variant="highlight"
+        />
+      </div>
+
+      {disposableIncome ? (
+        <div className="rounded-2xl border border-indigo-100 bg-indigo-50 p-6 text-indigo-900">
+          <h3 className="text-sm font-semibold uppercase tracking-wide">Disposable Income</h3>
+          <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-4 text-sm">
+            <div>
+              <dt className="text-indigo-700">Monthly</dt>
+              <dd className="text-xl font-semibold">{formatCurrency(disposableIncome.monthly)}</dd>
+            </div>
+            <div>
+              <dt className="text-indigo-700">Annual</dt>
+              <dd className="text-xl font-semibold">{formatCurrency(disposableIncome.annual)}</dd>
+            </div>
+            <div>
+              <dt className="text-indigo-700">Savings Rate</dt>
+              <dd className="text-xl font-semibold">{formatPercent(disposableIncome.savingsRate)}</dd>
+            </div>
+            <div>
+              <dt className="text-indigo-700">Emergency Fund</dt>
+              <dd className="text-xl font-semibold">
+                {disposableIncome.emergencyFundCoverageMonths
+                  ? `${Number(disposableIncome.emergencyFundCoverageMonths).toFixed(1)} months`
+                  : 'Not provided'}
+              </dd>
+            </div>
+          </div>
+          {disposableIncome.commentary ? <p className="mt-3 text-sm">{disposableIncome.commentary}</p> : null}
+        </div>
+      ) : null}
+
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+        <div className="space-y-4">
+          <BreakdownList
+            title="Income Breakdown"
+            entries={cashflowData?.incomeSummary?.annualBreakdown || cashflowData?.incomeBreakdown}
+          />
+          <BreakdownList
+            title="Expense Breakdown"
+            entries={cashflowData?.expenseSummary?.detail || cashflowData?.expenseBreakdown}
+          />
+        </div>
+        <div className="space-y-4">
+          <BreakdownList
+            title="Tax Figures"
+            entries={taxData?.figures || taxData?.detail}
+          />
+          {Array.isArray(taxData?.recommendations) && taxData.recommendations.length > 0 ? (
+            <div className="rounded-xl border border-emerald-100 bg-emerald-50 p-4 text-emerald-900">
+              <h3 className="text-sm font-semibold">Tax Planning Opportunities</h3>
+              <ul className="mt-2 space-y-1 list-disc list-inside text-sm">
+                {taxData.recommendations.map((item, index) => (
+                  <li key={index}>{item}</li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </ReportSection>
+  );
+};
+
+export default TaxAndCashflow;


### PR DESCRIPTION
## Summary
- replace the profile summary placeholder with structured household, employment, health, and reference details
- introduce a reusable report section wrapper plus a combined tax and cashflow component and register it in the report view
- refresh retirement and protection cards to honour the expanded payload and show helpful fallbacks

## Testing
- npm run lint *(fails: Cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_690ce0de1a788320b5b1857b00daaa5f