### PR TITLE
Add retirement and protection data capture across blueprint

### DIFF
--- a/src/pages/financial-blueprint/Step3_Expenses.jsx
+++ b/src/pages/financial-blueprint/Step3_Expenses.jsx
@@ -10,9 +10,19 @@ const Step3_Expenses = ({
   currentStep,
   totalSteps,
   register,
+  setValue,
 }) => {
   const numberOfChildren = Number(watch('numberOfChildren') || 0);
   const specialNeedsChildren = Number(watch('specialNeedsChildren') || 0);
+  const blueprintFor = watch('blueprintFor');
+
+  React.useEffect(() => {
+    if (blueprintFor !== 'family') {
+      const resetOptions = { shouldValidate: false, shouldDirty: false };
+      setValue('partnerPensionContributionMonthly', '0', resetOptions);
+      setValue('partnerIsaContributionMonthly', '0', resetOptions);
+    }
+  }, [blueprintFor, setValue]);
 
   return (
     <div className="space-y-8">
@@ -101,6 +111,80 @@ const Step3_Expenses = ({
           />
         ) : (
           <input type="hidden" {...register('specialNeedsCostsMonthly')} value="0" readOnly />
+        )}
+        <CurrencyInput
+          name="emergencySavingsContributionMonthly"
+          control={control}
+          label="Monthly emergency savings contribution"
+          placeholder="200"
+          helpText="Transfers into your emergency fund or rainy-day savings."
+          error={errors.emergencySavingsContributionMonthly}
+          minimumFractionDigits={0}
+          maximumFractionDigits={0}
+        />
+        <CurrencyInput
+          name="pensionContributionMonthly"
+          control={control}
+          label="Your monthly pension contributions"
+          placeholder="350"
+          helpText="Include workplace and personal pension contributions."
+          error={errors.pensionContributionMonthly}
+          minimumFractionDigits={0}
+          maximumFractionDigits={0}
+        />
+        {blueprintFor === 'family' ? (
+          <CurrencyInput
+            name="partnerPensionContributionMonthly"
+            control={control}
+            label="Partner’s monthly pension contributions"
+            placeholder="320"
+            error={errors.partnerPensionContributionMonthly}
+            minimumFractionDigits={0}
+            maximumFractionDigits={0}
+          />
+        ) : (
+          <input
+            type="hidden"
+            {...register('partnerPensionContributionMonthly')}
+            value="0"
+            readOnly
+          />
+        )}
+        <CurrencyInput
+          name="isaContributionMonthly"
+          control={control}
+          label="Monthly ISA investing"
+          placeholder="250"
+          helpText="Regular amounts invested into ISAs."
+          error={errors.isaContributionMonthly}
+          minimumFractionDigits={0}
+          maximumFractionDigits={0}
+        />
+        {blueprintFor === 'family' ? (
+          <CurrencyInput
+            name="partnerIsaContributionMonthly"
+            control={control}
+            label="Partner’s monthly ISA investing"
+            placeholder="200"
+            error={errors.partnerIsaContributionMonthly}
+            minimumFractionDigits={0}
+            maximumFractionDigits={0}
+          />
+        ) : (
+          <input type="hidden" {...register('partnerIsaContributionMonthly')} value="0" readOnly />
+        )}
+        {numberOfChildren > 0 ? (
+          <CurrencyInput
+            name="childcareVouchersMonthly"
+            control={control}
+            label="Childcare vouchers received each month"
+            placeholder="100"
+            error={errors.childcareVouchersMonthly}
+            minimumFractionDigits={0}
+            maximumFractionDigits={0}
+          />
+        ) : (
+          <input type="hidden" {...register('childcareVouchersMonthly')} value="0" readOnly />
         )}
       </div>
 

--- a/src/pages/financial-blueprint/Step4_Assets.jsx
+++ b/src/pages/financial-blueprint/Step4_Assets.jsx
@@ -24,6 +24,16 @@ const Step4_Assets = ({ onBack, onNext, control, errors, currentStep, totalSteps
           maximumFractionDigits={0}
         />
         <CurrencyInput
+          name="emergencyFundBalance"
+          control={control}
+          label="Emergency fund balance"
+          placeholder="6,000"
+          helpText="How much is set aside specifically for emergencies."
+          error={errors.emergencyFundBalance}
+          minimumFractionDigits={0}
+          maximumFractionDigits={0}
+        />
+        <CurrencyInput
           name="pensionValue"
           control={control}
           label="Total pension value"
@@ -39,6 +49,15 @@ const Step4_Assets = ({ onBack, onNext, control, errors, currentStep, totalSteps
           label="Primary residence value"
           placeholder="250,000"
           error={errors.propertyValue}
+          minimumFractionDigits={0}
+          maximumFractionDigits={0}
+        />
+        <CurrencyInput
+          name="isaInvestmentsValue"
+          control={control}
+          label="Investments held within ISAs"
+          placeholder="20,000"
+          error={errors.isaInvestmentsValue}
           minimumFractionDigits={0}
           maximumFractionDigits={0}
         />

--- a/src/pages/financial-blueprint/Step5_Liabilities.jsx
+++ b/src/pages/financial-blueprint/Step5_Liabilities.jsx
@@ -124,6 +124,16 @@ const Step5_Liabilities = ({
           minimumFractionDigits={0}
           maximumFractionDigits={0}
         />
+        <CurrencyInput
+          name="insurancePremiumsTotalMonthly"
+          control={control}
+          label="Total monthly insurance premiums"
+          placeholder="150"
+          helpText="Include life insurance, income protection and other policy costs."
+          error={errors.insurancePremiumsTotalMonthly}
+          minimumFractionDigits={0}
+          maximumFractionDigits={0}
+        />
       </div>
 
       <div className="flex justify-between">

--- a/src/pages/financial-blueprint/Step6_Mindset.jsx
+++ b/src/pages/financial-blueprint/Step6_Mindset.jsx
@@ -75,6 +75,26 @@ const Step6_Mindset = ({ onBack, onNext, register, errors, currentStep, totalSte
             { value: 'avoidant', label: 'I prefer to keep my money in cash savings accounts.' },
           ]}
         />
+        <MindsetQuestion
+          question="How do you feel about your emergency savings safety net?"
+          name="emergencySavingsConfidence"
+          register={register}
+          error={errors.emergencySavingsConfidence}
+          options={[
+            {
+              value: 'comfortable',
+              label: 'I have a healthy emergency fund that covers several months of expenses.',
+            },
+            {
+              value: 'building',
+              label: 'I’m actively building my emergency savings but not at my target yet.',
+            },
+            {
+              value: 'concerned',
+              label: 'I have little to no emergency savings and want guidance.',
+            },
+          ]}
+        />
       </div>
 
       <div className="flex justify-between">

--- a/src/pages/financial-blueprint/Step7_Protection.jsx
+++ b/src/pages/financial-blueprint/Step7_Protection.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import CurrencyInput from '@/components/form/CurrencyInput.jsx';
 
 const radioClass = 'form-radio h-4 w-4 text-indigo-600';
 
@@ -19,7 +20,53 @@ const RadioQuestion = ({ label, name, register, error }) => (
   </div>
 );
 
-const Step7_Protection = ({ onBack, onNext, register, errors, currentStep, totalSteps }) => {
+const Step7_Protection = ({
+  onBack,
+  onNext,
+  register,
+  errors,
+  control,
+  watch,
+  setValue,
+  currentStep,
+  totalSteps,
+}) => {
+  const blueprintFor = watch('blueprintFor');
+  const hasLifeInsurance = watch('hasLifeInsurance');
+  const hasIncomeProtection = watch('hasIncomeProtection');
+  const partnerHasLifeInsurance = watch('partnerHasLifeInsurance');
+  const partnerHasIncomeProtection = watch('partnerHasIncomeProtection');
+
+  React.useEffect(() => {
+    const resetMoney = (field) => setValue(field, '0', { shouldValidate: false, shouldDirty: false });
+    if (hasLifeInsurance !== 'yes') {
+      resetMoney('lifeInsuranceBenefitAmount');
+    }
+    if (hasIncomeProtection !== 'yes') {
+      resetMoney('incomeProtectionBenefitAmount');
+    }
+    if (blueprintFor !== 'family') {
+      setValue('partnerHasLifeInsurance', 'no', { shouldValidate: false, shouldDirty: false });
+      setValue('partnerHasIncomeProtection', 'no', { shouldValidate: false, shouldDirty: false });
+      resetMoney('partnerLifeInsuranceBenefitAmount');
+      resetMoney('partnerIncomeProtectionBenefitAmount');
+    } else {
+      if (partnerHasLifeInsurance !== 'yes') {
+        resetMoney('partnerLifeInsuranceBenefitAmount');
+      }
+      if (partnerHasIncomeProtection !== 'yes') {
+        resetMoney('partnerIncomeProtectionBenefitAmount');
+      }
+    }
+  }, [
+    blueprintFor,
+    hasIncomeProtection,
+    hasLifeInsurance,
+    partnerHasIncomeProtection,
+    partnerHasLifeInsurance,
+    setValue,
+  ]);
+
   return (
     <div className="space-y-8">
       <div className="text-center">
@@ -44,12 +91,119 @@ const Step7_Protection = ({ onBack, onNext, register, errors, currentStep, total
           register={register}
           error={errors.hasLifeInsurance}
         />
+        {hasLifeInsurance === 'yes' ? (
+          <CurrencyInput
+            name="lifeInsuranceBenefitAmount"
+            control={control}
+            label="Total life insurance benefit amount"
+            placeholder="150,000"
+            error={errors.lifeInsuranceBenefitAmount}
+            minimumFractionDigits={0}
+            maximumFractionDigits={0}
+          />
+        ) : (
+          <input type="hidden" {...register('lifeInsuranceBenefitAmount')} value="0" readOnly />
+        )}
+        {blueprintFor === 'family' ? (
+          <div className="space-y-4">
+            <RadioQuestion
+              label="Does your partner have life insurance?"
+              name="partnerHasLifeInsurance"
+              register={register}
+              error={errors.partnerHasLifeInsurance}
+            />
+            {partnerHasLifeInsurance === 'yes' ? (
+              <CurrencyInput
+                name="partnerLifeInsuranceBenefitAmount"
+                control={control}
+                label="Partner’s life insurance benefit amount"
+                placeholder="150,000"
+                error={errors.partnerLifeInsuranceBenefitAmount}
+                minimumFractionDigits={0}
+                maximumFractionDigits={0}
+              />
+            ) : (
+              <input
+                type="hidden"
+                {...register('partnerLifeInsuranceBenefitAmount')}
+                value="0"
+                readOnly
+              />
+            )}
+          </div>
+        ) : (
+          <>
+            <input type="hidden" {...register('partnerHasLifeInsurance')} value="no" readOnly />
+            <input
+              type="hidden"
+              {...register('partnerLifeInsuranceBenefitAmount')}
+              value="0"
+              readOnly
+            />
+          </>
+        )}
         <RadioQuestion
           label="Do you have income protection insurance?"
           name="hasIncomeProtection"
           register={register}
           error={errors.hasIncomeProtection}
         />
+        {hasIncomeProtection === 'yes' ? (
+          <CurrencyInput
+            name="incomeProtectionBenefitAmount"
+            control={control}
+            label="Monthly income protection benefit"
+            placeholder="2,000"
+            error={errors.incomeProtectionBenefitAmount}
+            minimumFractionDigits={0}
+            maximumFractionDigits={0}
+          />
+        ) : (
+          <input
+            type="hidden"
+            {...register('incomeProtectionBenefitAmount')}
+            value="0"
+            readOnly
+          />
+        )}
+        {blueprintFor === 'family' ? (
+          <div className="space-y-4">
+            <RadioQuestion
+              label="Does your partner have income protection insurance?"
+              name="partnerHasIncomeProtection"
+              register={register}
+              error={errors.partnerHasIncomeProtection}
+            />
+            {partnerHasIncomeProtection === 'yes' ? (
+              <CurrencyInput
+                name="partnerIncomeProtectionBenefitAmount"
+                control={control}
+                label="Partner’s monthly income protection benefit"
+                placeholder="2,000"
+                error={errors.partnerIncomeProtectionBenefitAmount}
+                minimumFractionDigits={0}
+                maximumFractionDigits={0}
+              />
+            ) : (
+              <input
+                type="hidden"
+                {...register('partnerIncomeProtectionBenefitAmount')}
+                value="0"
+                readOnly
+              />
+            )}
+          </div>
+        ) : (
+          <>
+            <input type="hidden" {...register('partnerHasIncomeProtection')} value="no" readOnly />
+            <input
+              type="hidden"
+              {...register('partnerIncomeProtectionBenefitAmount')}
+              value="0"
+              readOnly
+            />
+          </>
+        )}
         <RadioQuestion
           label="Do you have a lasting power of attorney (LPA)?"
           name="hasLPA"

--- a/src/pages/financial-blueprint/Step8_RetirementGoals.jsx
+++ b/src/pages/financial-blueprint/Step8_RetirementGoals.jsx
@@ -1,0 +1,187 @@
+import React from 'react';
+import CurrencyInput from '@/components/form/CurrencyInput.jsx';
+
+const numberInputClass =
+  'mt-1 block w-full rounded-md border-gray-400 bg-white shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm px-3 py-2';
+
+const Step8_RetirementGoals = ({
+  onBack,
+  onNext,
+  control,
+  register,
+  errors,
+  watch,
+  setValue,
+  currentStep,
+  totalSteps,
+}) => {
+  const blueprintFor = watch('blueprintFor');
+
+  React.useEffect(() => {
+    if (blueprintFor !== 'family') {
+      const options = { shouldValidate: false, shouldDirty: false };
+      setValue('partnerRetirementTargetAge', '0', options);
+      setValue('partnerRetirementIncomeTargetMonthly', '0', options);
+    }
+  }, [blueprintFor, setValue]);
+
+  return (
+    <div className="space-y-8">
+      <div className="text-center">
+        <h2 className="text-2xl font-bold">
+          Step {currentStep} of {totalSteps}: Retirement goals
+        </h2>
+        <p className="mt-2 text-gray-600">
+          Share the milestones you’re working toward so we can tailor long-term planning guidance.
+        </p>
+      </div>
+
+      <div className="space-y-6 rounded-lg bg-gray-50 p-6 border border-gray-200">
+        <div>
+          <label htmlFor="retirementTargetAge" className="block text-sm font-medium text-gray-700">
+            Target retirement age
+          </label>
+          <input
+            id="retirementTargetAge"
+            type="number"
+            min={50}
+            max={80}
+            step="1"
+            {...register('retirementTargetAge')}
+            className={numberInputClass}
+          />
+          {errors.retirementTargetAge ? (
+            <p className="mt-1 text-sm text-red-600">{errors.retirementTargetAge.message}</p>
+          ) : null}
+        </div>
+
+        {blueprintFor === 'family' ? (
+          <div>
+            <label
+              htmlFor="partnerRetirementTargetAge"
+              className="block text-sm font-medium text-gray-700"
+            >
+              Partner’s target retirement age
+            </label>
+            <input
+              id="partnerRetirementTargetAge"
+              type="number"
+              min={50}
+              max={80}
+              step="1"
+              {...register('partnerRetirementTargetAge')}
+              className={numberInputClass}
+            />
+            {errors.partnerRetirementTargetAge ? (
+              <p className="mt-1 text-sm text-red-600">{errors.partnerRetirementTargetAge.message}</p>
+            ) : null}
+          </div>
+        ) : (
+          <input type="hidden" {...register('partnerRetirementTargetAge')} value="0" readOnly />
+        )}
+
+        <CurrencyInput
+          name="retirementIncomeTargetMonthly"
+          control={control}
+          label="Desired monthly income in retirement"
+          placeholder="3,000"
+          helpText="What monthly income would let you live comfortably once you stop working?"
+          error={errors.retirementIncomeTargetMonthly}
+          minimumFractionDigits={0}
+          maximumFractionDigits={0}
+        />
+
+        {blueprintFor === 'family' ? (
+          <CurrencyInput
+            name="partnerRetirementIncomeTargetMonthly"
+            control={control}
+            label="Partner’s desired monthly retirement income"
+            placeholder="2,800"
+            error={errors.partnerRetirementIncomeTargetMonthly}
+            minimumFractionDigits={0}
+            maximumFractionDigits={0}
+          />
+        ) : (
+          <input
+            type="hidden"
+            {...register('partnerRetirementIncomeTargetMonthly')}
+            value="0"
+            readOnly
+          />
+        )}
+
+        <div>
+          <label
+            htmlFor="statePensionQualifyingYears"
+            className="block text-sm font-medium text-gray-700"
+          >
+            Qualifying National Insurance years
+          </label>
+          <input
+            id="statePensionQualifyingYears"
+            type="number"
+            min={0}
+            max={60}
+            step="1"
+            {...register('statePensionQualifyingYears')}
+            className={numberInputClass}
+          />
+          {errors.statePensionQualifyingYears ? (
+            <p className="mt-1 text-sm text-red-600">{errors.statePensionQualifyingYears.message}</p>
+          ) : null}
+        </div>
+
+        <div>
+          <label
+            htmlFor="statePensionLastStatementYear"
+            className="block text-sm font-medium text-gray-700"
+          >
+            Year you last checked your state pension
+          </label>
+          <input
+            id="statePensionLastStatementYear"
+            type="number"
+            min={1990}
+            max={new Date().getFullYear()}
+            step="1"
+            {...register('statePensionLastStatementYear')}
+            className={numberInputClass}
+          />
+          {errors.statePensionLastStatementYear ? (
+            <p className="mt-1 text-sm text-red-600">{errors.statePensionLastStatementYear.message}</p>
+          ) : null}
+        </div>
+
+        <CurrencyInput
+          name="statePensionForecastAmountMonthly"
+          control={control}
+          label="Estimated monthly state pension"
+          placeholder="750"
+          helpText="Use £0 if you haven’t checked your forecast yet."
+          error={errors.statePensionForecastAmountMonthly}
+          minimumFractionDigits={0}
+          maximumFractionDigits={0}
+        />
+      </div>
+
+      <div className="flex justify-between">
+        <button
+          type="button"
+          onClick={onBack}
+          className="inline-flex justify-center rounded-md border border-gray-300 bg-white py-2 px-4 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50"
+        >
+          Back
+        </button>
+        <button
+          type="button"
+          onClick={onNext}
+          className="inline-flex justify-center rounded-md border border-transparent bg-indigo-600 py-2 px-4 text-sm font-medium text-white shadow-sm hover:bg-indigo-700"
+        >
+          Continue
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default Step8_RetirementGoals;

--- a/src/pages/financial-blueprint/Step8_Review.jsx
+++ b/src/pages/financial-blueprint/Step8_Review.jsx
@@ -38,6 +38,11 @@ const friendlyText = {
     cautious: 'Cautious / exploring',
     avoidant: 'Prefer cash savings',
   },
+  emergencySavingsConfidence: {
+    comfortable: 'Comfortable with current buffer',
+    building: 'Actively building emergency savings',
+    concerned: 'Concerned about emergency savings',
+  },
   yesNo: { yes: 'Yes', no: 'No' },
 };
 
@@ -82,11 +87,23 @@ const Step8_Review = ({ onBack, onConfirm, values, isLoading }) => {
       ['Lifestyle & entertainment', formatGBP(values.expensesLifestyle)],
       ['Childcare & education', formatGBP(values.expensesChildcare)],
       ['Special needs support', formatGBP(values.specialNeedsCostsMonthly)],
-    ],
+      ['Emergency savings contributions', formatGBP(values.emergencySavingsContributionMonthly)],
+      ['Your pension contributions', formatGBP(values.pensionContributionMonthly)],
+      values.blueprintFor === 'family'
+        ? ["Partner pension contributions", formatGBP(values.partnerPensionContributionMonthly)]
+        : null,
+      ['Monthly ISA investing', formatGBP(values.isaContributionMonthly)],
+      values.blueprintFor === 'family'
+        ? ["Partner ISA investing", formatGBP(values.partnerIsaContributionMonthly)]
+        : null,
+      ['Childcare vouchers received', formatGBP(values.childcareVouchersMonthly)],
+    ].filter(Boolean),
     assets: [
       ['Cash savings', formatGBP(values.cashSavings)],
+      ['Emergency fund balance', formatGBP(values.emergencyFundBalance)],
       ['Pension value', formatGBP(values.pensionValue)],
       ['Property value', formatGBP(values.propertyValue)],
+      ['Investments held in ISAs', formatGBP(values.isaInvestmentsValue)],
       ['Other investments', formatGBP(values.otherInvestments)],
       ['Other assets', formatGBP(values.otherAssets)],
     ],
@@ -98,18 +115,182 @@ const Step8_Review = ({ onBack, onConfirm, values, isLoading }) => {
       ['Credit card debt', formatGBP(values.creditCardDebt)],
       ['Other loans', formatGBP(values.otherLoans)],
       ['Student loan balance', formatGBP(values.studentLoanBalance)],
+      ['Insurance premiums (monthly total)', formatGBP(values.insurancePremiumsTotalMonthly)],
     ],
     mindset: [
       ['Earning habit', friendlyText.earningHabit[values.earningHabit] || values.earningHabit || '—'],
       ['Saving habit', friendlyText.savingHabit[values.savingHabit] || values.savingHabit || '—'],
       ['Investing habit', friendlyText.investingHabit[values.investingHabit] || values.investingHabit || '—'],
+      [
+        'Emergency savings confidence',
+        friendlyText.emergencySavingsConfidence[values.emergencySavingsConfidence] ||
+          values.emergencySavingsConfidence ||
+          '—',
+      ],
     ],
     protection: [
       ['Will in place', friendlyText.yesNo[values.hasWill] || values.hasWill || '—'],
       ['Life insurance', friendlyText.yesNo[values.hasLifeInsurance] || values.hasLifeInsurance || '—'],
+      [
+        'Life insurance benefit',
+        formatGBP(values.lifeInsuranceBenefitAmount, {
+          minimumFractionDigits: 0,
+          maximumFractionDigits: 0,
+        }),
+      ],
       ['Income protection', friendlyText.yesNo[values.hasIncomeProtection] || values.hasIncomeProtection || '—'],
+      [
+        'Income protection benefit',
+        formatGBP(values.incomeProtectionBenefitAmount, {
+          minimumFractionDigits: 0,
+          maximumFractionDigits: 0,
+        }),
+      ],
       ['Lasting power of attorney', friendlyText.yesNo[values.hasLPA] || values.hasLPA || '—'],
-    ],
+      values.blueprintFor === 'family'
+        ? [
+            'Partner life insurance',
+            friendlyText.yesNo[values.partnerHasLifeInsurance] ||
+              values.partnerHasLifeInsurance ||
+              '—',
+          ]
+        : null,
+      values.blueprintFor === 'family'
+        ? [
+            'Partner life insurance benefit',
+            formatGBP(values.partnerLifeInsuranceBenefitAmount, {
+              minimumFractionDigits: 0,
+              maximumFractionDigits: 0,
+            }),
+          ]
+        : null,
+      values.blueprintFor === 'family'
+        ? [
+            'Partner income protection',
+            friendlyText.yesNo[values.partnerHasIncomeProtection] ||
+              values.partnerHasIncomeProtection ||
+              '—',
+          ]
+        : null,
+      values.blueprintFor === 'family'
+        ? [
+            'Partner income protection benefit',
+            formatGBP(values.partnerIncomeProtectionBenefitAmount, {
+              minimumFractionDigits: 0,
+              maximumFractionDigits: 0,
+            }),
+          ]
+        : null,
+    ].filter(Boolean),
+    retirement: [
+      ['Target retirement age', values.retirementTargetAge || '—'],
+      values.blueprintFor === 'family'
+        ? ["Partner target retirement age", values.partnerRetirementTargetAge || '—']
+        : null,
+      ['Desired retirement income (monthly)', formatGBP(values.retirementIncomeTargetMonthly)],
+      values.blueprintFor === 'family'
+        ? [
+            "Partner retirement income target",
+            formatGBP(values.partnerRetirementIncomeTargetMonthly),
+          ]
+        : null,
+      ['Qualifying NI years', values.statePensionQualifyingYears || '0'],
+      ['Last checked state pension', values.statePensionLastStatementYear || '—'],
+      ['Estimated state pension (monthly)', formatGBP(values.statePensionForecastAmountMonthly)],
+    ].filter(Boolean),
+    protectionDetails: [
+      [
+        'Life insurance provider',
+        values.lifeInsuranceProvider && values.lifeInsuranceProvider.trim().length > 0
+          ? values.lifeInsuranceProvider
+          : '—',
+      ],
+      ['Life insurance sum assured', formatGBP(values.lifeInsuranceSumAssured)],
+      ['Life insurance premium (monthly)', formatGBP(values.lifeInsurancePremiumMonthlyDetail)],
+      [
+        'Life insurance beneficiary notes',
+        values.lifeInsuranceBeneficiaryNotes && values.lifeInsuranceBeneficiaryNotes.trim().length > 0
+          ? values.lifeInsuranceBeneficiaryNotes
+          : '—',
+      ],
+      [
+        'Income protection insurer',
+        values.incomeProtectionProvider && values.incomeProtectionProvider.trim().length > 0
+          ? values.incomeProtectionProvider
+          : '—',
+      ],
+      ['Income protection monthly benefit', formatGBP(values.incomeProtectionBenefitMonthly)],
+      [
+        'Income protection premium (monthly)',
+        formatGBP(values.incomeProtectionPremiumMonthlyDetail),
+      ],
+      [
+        'Income protection notes',
+        values.incomeProtectionBeneficiaryNotes &&
+        values.incomeProtectionBeneficiaryNotes.trim().length > 0
+          ? values.incomeProtectionBeneficiaryNotes
+          : '—',
+      ],
+      values.blueprintFor === 'family'
+        ? [
+            'Partner life insurance provider',
+            values.partnerLifeInsuranceProvider && values.partnerLifeInsuranceProvider.trim().length > 0
+              ? values.partnerLifeInsuranceProvider
+              : '—',
+          ]
+        : null,
+      values.blueprintFor === 'family'
+        ? [
+            'Partner life insurance sum assured',
+            formatGBP(values.partnerLifeInsuranceSumAssured),
+          ]
+        : null,
+      values.blueprintFor === 'family'
+        ? [
+            'Partner life insurance premium (monthly)',
+            formatGBP(values.partnerLifeInsurancePremiumMonthlyDetail),
+          ]
+        : null,
+      values.blueprintFor === 'family'
+        ? [
+            'Partner life insurance notes',
+            values.partnerLifeInsuranceBeneficiaryNotes &&
+            values.partnerLifeInsuranceBeneficiaryNotes.trim().length > 0
+              ? values.partnerLifeInsuranceBeneficiaryNotes
+              : '—',
+          ]
+        : null,
+      values.blueprintFor === 'family'
+        ? [
+            'Partner income protection insurer',
+            values.partnerIncomeProtectionProvider &&
+            values.partnerIncomeProtectionProvider.trim().length > 0
+              ? values.partnerIncomeProtectionProvider
+              : '—',
+          ]
+        : null,
+      values.blueprintFor === 'family'
+        ? [
+            'Partner income protection monthly benefit',
+            formatGBP(values.partnerIncomeProtectionBenefitMonthly),
+          ]
+        : null,
+      values.blueprintFor === 'family'
+        ? [
+            'Partner income protection premium (monthly)',
+            formatGBP(values.partnerIncomeProtectionPremiumMonthlyDetail),
+          ]
+        : null,
+      values.blueprintFor === 'family'
+        ? [
+            'Partner income protection notes',
+            values.partnerIncomeProtectionBeneficiaryNotes &&
+            values.partnerIncomeProtectionBeneficiaryNotes.trim().length > 0
+              ? values.partnerIncomeProtectionBeneficiaryNotes
+              : '—',
+          ]
+        : null,
+    ].filter(Boolean),
   }), [values]);
 
   return (
@@ -147,16 +328,26 @@ const Step8_Review = ({ onBack, onConfirm, values, isLoading }) => {
             <LineItem key={label} label={label} value={value} />
           ))}
         </Section>
-        <Section title="Mindset & behaviours">
-          {summary.mindset.map(([label, value]) => (
-            <LineItem key={label} label={label} value={value} />
-          ))}
-        </Section>
-        <Section title="Protection">
-          {summary.protection.map(([label, value]) => (
-            <LineItem key={label} label={label} value={value} />
-          ))}
-        </Section>
+      <Section title="Mindset & behaviours">
+        {summary.mindset.map(([label, value]) => (
+          <LineItem key={label} label={label} value={value} />
+        ))}
+      </Section>
+      <Section title="Protection">
+        {summary.protection.map(([label, value]) => (
+          <LineItem key={label} label={label} value={value} />
+        ))}
+      </Section>
+      <Section title="Retirement goals">
+        {summary.retirement.map(([label, value]) => (
+          <LineItem key={label} label={label} value={value} />
+        ))}
+      </Section>
+      <Section title="Protection policy details">
+        {summary.protectionDetails.map(([label, value]) => (
+          <LineItem key={label} label={label} value={value} />
+        ))}
+      </Section>
       </div>
 
       <div className="flex justify-between">

--- a/src/pages/financial-blueprint/Step9_ProtectionDetails.jsx
+++ b/src/pages/financial-blueprint/Step9_ProtectionDetails.jsx
@@ -1,0 +1,289 @@
+import React from 'react';
+import CurrencyInput from '@/components/form/CurrencyInput.jsx';
+
+const inputClass =
+  'mt-1 block w-full rounded-md border-gray-400 bg-white shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm px-3 py-2';
+
+const textareaClass =
+  'mt-1 block w-full rounded-md border-gray-400 bg-white shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm px-3 py-2';
+
+const Step9_ProtectionDetails = ({
+  onBack,
+  onNext,
+  control,
+  register,
+  errors,
+  watch,
+  setValue,
+  currentStep,
+  totalSteps,
+}) => {
+  const blueprintFor = watch('blueprintFor');
+  const hasLifeInsurance = watch('hasLifeInsurance');
+  const hasIncomeProtection = watch('hasIncomeProtection');
+  const partnerHasLifeInsurance = watch('partnerHasLifeInsurance');
+  const partnerHasIncomeProtection = watch('partnerHasIncomeProtection');
+
+  const resetField = React.useCallback(
+    (field, value = '') => setValue(field, value, { shouldValidate: false, shouldDirty: false }),
+    [setValue]
+  );
+
+  React.useEffect(() => {
+    if (hasLifeInsurance !== 'yes') {
+      resetField('lifeInsuranceProvider');
+      resetField('lifeInsuranceSumAssured', '0');
+      resetField('lifeInsurancePremiumMonthlyDetail', '0');
+      resetField('lifeInsuranceBeneficiaryNotes');
+    }
+  }, [hasLifeInsurance, resetField]);
+
+  React.useEffect(() => {
+    if (hasIncomeProtection !== 'yes') {
+      resetField('incomeProtectionProvider');
+      resetField('incomeProtectionBenefitMonthly', '0');
+      resetField('incomeProtectionPremiumMonthlyDetail', '0');
+      resetField('incomeProtectionBeneficiaryNotes');
+    }
+  }, [hasIncomeProtection, resetField]);
+
+  React.useEffect(() => {
+    if (blueprintFor !== 'family') {
+      resetField('partnerHasLifeInsurance', 'no');
+      resetField('partnerHasIncomeProtection', 'no');
+    }
+  }, [blueprintFor, resetField]);
+
+  React.useEffect(() => {
+    if (partnerHasLifeInsurance !== 'yes') {
+      resetField('partnerLifeInsuranceProvider');
+      resetField('partnerLifeInsuranceSumAssured', '0');
+      resetField('partnerLifeInsurancePremiumMonthlyDetail', '0');
+      resetField('partnerLifeInsuranceBeneficiaryNotes');
+    }
+  }, [partnerHasLifeInsurance, resetField]);
+
+  React.useEffect(() => {
+    if (partnerHasIncomeProtection !== 'yes') {
+      resetField('partnerIncomeProtectionProvider');
+      resetField('partnerIncomeProtectionBenefitMonthly', '0');
+      resetField('partnerIncomeProtectionPremiumMonthlyDetail', '0');
+      resetField('partnerIncomeProtectionBeneficiaryNotes');
+    }
+  }, [partnerHasIncomeProtection, resetField]);
+
+  const renderLifeInsuranceSection = (fieldPrefix, title, showFields) => {
+    const providerField = `${fieldPrefix}Provider`;
+    const sumField = `${fieldPrefix}SumAssured`;
+    const premiumField = `${fieldPrefix}PremiumMonthlyDetail`;
+    const notesField = `${fieldPrefix}BeneficiaryNotes`;
+    const idPrefix = fieldPrefix;
+
+    return (
+    <div className="space-y-4">
+      <h3 className="text-lg font-semibold text-gray-800">{title}</h3>
+      {showFields ? (
+        <>
+          <div>
+            <label className="block text-sm font-medium text-gray-700" htmlFor={`${idPrefix}Provider`}>
+              Insurer name
+            </label>
+            <input
+              id={`${idPrefix}Provider`}
+              type="text"
+              {...register(providerField)}
+              className={inputClass}
+            />
+            {errors[providerField] ? (
+              <p className="mt-1 text-sm text-red-600">
+                {errors[providerField].message}
+              </p>
+            ) : null}
+          </div>
+          <CurrencyInput
+            name={sumField}
+            control={control}
+            label="Sum assured"
+            placeholder="200,000"
+            error={errors[sumField]}
+            minimumFractionDigits={0}
+            maximumFractionDigits={0}
+          />
+          <CurrencyInput
+            name={premiumField}
+            control={control}
+            label="Monthly premium"
+            placeholder="40"
+            error={errors[premiumField]}
+            minimumFractionDigits={0}
+            maximumFractionDigits={0}
+          />
+          <div>
+            <label
+              className="block text-sm font-medium text-gray-700"
+              htmlFor={`${idPrefix}BeneficiaryNotes`}
+            >
+              Beneficiary notes (optional)
+            </label>
+            <textarea
+              id={`${idPrefix}BeneficiaryNotes`}
+              rows={3}
+              {...register(notesField)}
+              className={textareaClass}
+            />
+            {errors[notesField] ? (
+              <p className="mt-1 text-sm text-red-600">
+                {errors[notesField].message}
+              </p>
+            ) : null}
+          </div>
+        </>
+      ) : (
+        <>
+          <input type="hidden" {...register(providerField)} value="" readOnly />
+          <input type="hidden" {...register(sumField)} value="0" readOnly />
+          <input type="hidden" {...register(premiumField)} value="0" readOnly />
+          <input type="hidden" {...register(notesField)} value="" readOnly />
+        </>
+      )}
+    </div>
+  );
+  };
+
+  const renderIncomeProtectionSection = (fieldPrefix, title, showFields) => {
+    const providerField = `${fieldPrefix}Provider`;
+    const benefitField = `${fieldPrefix}BenefitMonthly`;
+    const premiumField = `${fieldPrefix}PremiumMonthlyDetail`;
+    const notesField = `${fieldPrefix}BeneficiaryNotes`;
+    const idPrefix = fieldPrefix;
+
+    return (
+    <div className="space-y-4">
+      <h3 className="text-lg font-semibold text-gray-800">{title}</h3>
+      {showFields ? (
+        <>
+          <div>
+            <label className="block text-sm font-medium text-gray-700" htmlFor={`${idPrefix}Provider`}>
+              Insurer name
+            </label>
+            <input
+              id={`${idPrefix}Provider`}
+              type="text"
+              {...register(providerField)}
+              className={inputClass}
+            />
+            {errors[providerField] ? (
+              <p className="mt-1 text-sm text-red-600">
+                {errors[providerField].message}
+              </p>
+            ) : null}
+          </div>
+          <CurrencyInput
+            name={benefitField}
+            control={control}
+            label="Monthly benefit"
+            placeholder="2,000"
+            error={errors[benefitField]}
+            minimumFractionDigits={0}
+            maximumFractionDigits={0}
+          />
+          <CurrencyInput
+            name={premiumField}
+            control={control}
+            label="Monthly premium"
+            placeholder="60"
+            error={errors[premiumField]}
+            minimumFractionDigits={0}
+            maximumFractionDigits={0}
+          />
+          <div>
+            <label
+              className="block text-sm font-medium text-gray-700"
+              htmlFor={`${idPrefix}BeneficiaryNotes`}
+            >
+              Notes on payout or beneficiaries (optional)
+            </label>
+            <textarea
+              id={`${idPrefix}BeneficiaryNotes`}
+              rows={3}
+              {...register(notesField)}
+              className={textareaClass}
+            />
+            {errors[notesField] ? (
+              <p className="mt-1 text-sm text-red-600">
+                {errors[notesField].message}
+              </p>
+            ) : null}
+          </div>
+        </>
+      ) : (
+        <>
+          <input type="hidden" {...register(providerField)} value="" readOnly />
+          <input type="hidden" {...register(benefitField)} value="0" readOnly />
+          <input type="hidden" {...register(premiumField)} value="0" readOnly />
+          <input type="hidden" {...register(notesField)} value="" readOnly />
+        </>
+      )}
+    </div>
+  );
+  };
+
+  return (
+    <div className="space-y-8">
+      <div className="text-center">
+        <h2 className="text-2xl font-bold">
+          Step {currentStep} of {totalSteps}: Protection policy details
+        </h2>
+        <p className="mt-2 text-gray-600">
+          Capture the specifics of your protection policies so we can highlight strengths and gaps.
+        </p>
+      </div>
+
+      <div className="space-y-8 rounded-lg bg-gray-50 p-6 border border-gray-200">
+        {renderLifeInsuranceSection('lifeInsurance', 'Your life insurance', hasLifeInsurance === 'yes')}
+        {renderIncomeProtectionSection('incomeProtection', 'Your income protection', hasIncomeProtection === 'yes')}
+
+        {blueprintFor === 'family'
+          ? (
+              <>
+                {renderLifeInsuranceSection(
+                  'partnerLifeInsurance',
+                  'Partner’s life insurance',
+                  partnerHasLifeInsurance === 'yes'
+                )}
+                {renderIncomeProtectionSection(
+                  'partnerIncomeProtection',
+                  'Partner’s income protection',
+                  partnerHasIncomeProtection === 'yes'
+                )}
+              </>
+            )
+          : (
+              <>
+                {renderLifeInsuranceSection('partnerLifeInsurance', 'Partner’s life insurance', false)}
+                {renderIncomeProtectionSection('partnerIncomeProtection', 'Partner’s income protection', false)}
+              </>
+            )}
+      </div>
+
+      <div className="flex justify-between">
+        <button
+          type="button"
+          onClick={onBack}
+          className="inline-flex justify-center rounded-md border border-gray-300 bg-white py-2 px-4 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50"
+        >
+          Back
+        </button>
+        <button
+          type="button"
+          onClick={onNext}
+          className="inline-flex justify-center rounded-md border border-transparent bg-indigo-600 py-2 px-4 text-sm font-medium text-white shadow-sm hover:bg-indigo-700"
+        >
+          Continue
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default Step9_ProtectionDetails;

--- a/src/pages/financial-blueprint/SurveyPage.jsx
+++ b/src/pages/financial-blueprint/SurveyPage.jsx
@@ -13,6 +13,8 @@ import {
   step5Schema,
   step6Schema,
   step7Schema,
+  step8Schema,
+  step9Schema,
 } from './schemas';
 import Step1_Profile from './Step1_Profile';
 import Step2_Income from './Step2_Income';
@@ -21,6 +23,8 @@ import Step4_Assets from './Step4_Assets';
 import Step5_Liabilities from './Step5_Liabilities';
 import Step6_Mindset from './Step6_Mindset';
 import Step7_Protection from './Step7_Protection';
+import Step8_RetirementGoals from './Step8_RetirementGoals';
+import Step9_ProtectionDetails from './Step9_ProtectionDetails';
 import Step8_Review from './Step8_Review';
 
 const SurveyPage = () => {
@@ -35,6 +39,8 @@ const SurveyPage = () => {
       { Component: Step5_Liabilities, schema: step5Schema },
       { Component: Step6_Mindset, schema: step6Schema },
       { Component: Step7_Protection, schema: step7Schema },
+      { Component: Step8_RetirementGoals, schema: step8Schema },
+      { Component: Step9_ProtectionDetails, schema: step9Schema },
       { Component: Step8_Review, schema: null, isReview: true },
     ],
     []
@@ -80,9 +86,17 @@ const SurveyPage = () => {
       expensesLifestyle: '0',
       expensesChildcare: '0',
       specialNeedsCostsMonthly: '0',
+      emergencySavingsContributionMonthly: '0',
+      pensionContributionMonthly: '0',
+      partnerPensionContributionMonthly: '0',
+      isaContributionMonthly: '0',
+      partnerIsaContributionMonthly: '0',
+      childcareVouchersMonthly: '0',
       cashSavings: '0',
+      emergencyFundBalance: '0',
       pensionValue: '0',
       propertyValue: '0',
+      isaInvestmentsValue: '0',
       otherInvestments: '0',
       otherAssets: '0',
       monthlyRent: '0',
@@ -92,13 +106,44 @@ const SurveyPage = () => {
       creditCardDebt: '0',
       otherLoans: '0',
       studentLoanBalance: '0',
+      insurancePremiumsTotalMonthly: '0',
       earningHabit: '',
       savingHabit: '',
       investingHabit: '',
+      emergencySavingsConfidence: '',
       hasWill: '',
       hasLifeInsurance: '',
+      partnerHasLifeInsurance: 'no',
+      lifeInsuranceBenefitAmount: '0',
+      partnerLifeInsuranceBenefitAmount: '0',
       hasIncomeProtection: '',
+      partnerHasIncomeProtection: 'no',
+      incomeProtectionBenefitAmount: '0',
+      partnerIncomeProtectionBenefitAmount: '0',
       hasLPA: '',
+      retirementTargetAge: '0',
+      partnerRetirementTargetAge: '0',
+      retirementIncomeTargetMonthly: '0',
+      partnerRetirementIncomeTargetMonthly: '0',
+      statePensionQualifyingYears: '0',
+      statePensionLastStatementYear: '0',
+      statePensionForecastAmountMonthly: '0',
+      lifeInsuranceProvider: '',
+      lifeInsuranceSumAssured: '0',
+      lifeInsurancePremiumMonthlyDetail: '0',
+      lifeInsuranceBeneficiaryNotes: '',
+      incomeProtectionProvider: '',
+      incomeProtectionBenefitMonthly: '0',
+      incomeProtectionPremiumMonthlyDetail: '0',
+      incomeProtectionBeneficiaryNotes: '',
+      partnerLifeInsuranceProvider: '',
+      partnerLifeInsuranceSumAssured: '0',
+      partnerLifeInsurancePremiumMonthlyDetail: '0',
+      partnerLifeInsuranceBeneficiaryNotes: '',
+      partnerIncomeProtectionProvider: '',
+      partnerIncomeProtectionBenefitMonthly: '0',
+      partnerIncomeProtectionPremiumMonthlyDetail: '0',
+      partnerIncomeProtectionBeneficiaryNotes: '',
     },
     shouldUnregister: false,
   });


### PR DESCRIPTION
## Summary
- extend the financial blueprint schemas to collect contribution, protection, and retirement planning data for both individuals and partners
- add UI inputs across the expenses, assets, liabilities, mindset, and protection steps plus new retirement goal and protection detail steps with appropriate conditional logic
- update the survey defaults and review summary so all new answers persist through validation and can be edited before submission

## Testing
- `npm run lint` *(fails: missing @eslint/js in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_690ce258e4bc832091dada6de5685992