### PR TITLE
Streamline housing inputs and enhance mortgage calculations

### DIFF
--- a/src/pages/financial-blueprint/Step5_Liabilities.jsx
+++ b/src/pages/financial-blueprint/Step5_Liabilities.jsx
@@ -24,11 +24,8 @@ const Step5_Liabilities = ({
     const resetOptions = { shouldValidate: false, shouldDirty: false };
     if (housingStatus !== 'mortgaged') {
       setValue('mortgageBalance', '0', resetOptions);
-      setValue('mortgageMonthlyPayment', '0', resetOptions);
+      setValue('mortgageInterestRatePercent', '0', resetOptions);
       setValue('mortgageRemainingTermYears', '0', resetOptions);
-    }
-    if (housingStatus !== 'renting') {
-      setValue('monthlyRent', '0', resetOptions);
     }
   }, [housingStatus, setValue]);
 
@@ -44,18 +41,6 @@ const Step5_Liabilities = ({
       </div>
 
       <div className="space-y-6 rounded-lg bg-gray-50 p-6 border border-gray-200">
-        {housingStatus === 'renting' ? (
-          <CurrencyInput
-            name="monthlyRent"
-            control={control}
-            label="Monthly rent"
-            placeholder="1,200"
-            error={errors.monthlyRent}
-            minimumFractionDigits={0}
-            maximumFractionDigits={0}
-          />
-        ) : null}
-
         {housingStatus === 'mortgaged' ? (
           <div className="space-y-6">
             <CurrencyInput
@@ -67,15 +52,23 @@ const Step5_Liabilities = ({
               minimumFractionDigits={0}
               maximumFractionDigits={0}
             />
-            <CurrencyInput
-              name="mortgageMonthlyPayment"
-              control={control}
-              label="Monthly mortgage payment"
-              placeholder="1,100"
-              error={errors.mortgageMonthlyPayment}
-              minimumFractionDigits={0}
-              maximumFractionDigits={0}
-            />
+            <div>
+              <label htmlFor="mortgageInterestRatePercent" className="block text-sm font-medium text-gray-700">
+                Mortgage interest rate (annual %)
+              </label>
+              <input
+                id="mortgageInterestRatePercent"
+                type="number"
+                min={0}
+                step="0.01"
+                {...register('mortgageInterestRatePercent')}
+                className="mt-1 block w-full rounded-md border-gray-400 bg-white shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm px-3 py-2"
+              />
+              {errors.mortgageInterestRatePercent ? (
+                <p className="mt-1 text-sm text-red-600">{errors.mortgageInterestRatePercent.message}</p>
+              ) : null}
+              <p className="mt-1 text-xs text-gray-500">Enter the headline rate on your current mortgage deal.</p>
+            </div>
             <div>
               <label htmlFor="mortgageRemainingTermYears" className="block text-sm font-medium text-gray-700">
                 Years remaining on mortgage

--- a/src/pages/financial-blueprint/SurveyPage.jsx
+++ b/src/pages/financial-blueprint/SurveyPage.jsx
@@ -99,9 +99,8 @@ const SurveyPage = () => {
       isaInvestmentsValue: '0',
       otherInvestments: '0',
       otherAssets: '0',
-      monthlyRent: '0',
       mortgageBalance: '0',
-      mortgageMonthlyPayment: '0',
+      mortgageInterestRatePercent: '0',
       mortgageRemainingTermYears: '0',
       creditCardDebt: '0',
       otherLoans: '0',
@@ -196,12 +195,13 @@ const SurveyPage = () => {
     const payloadSource = { ...latestValues, ...finalData };
     setIsLoading(true);
     setSubmissionError(null);
-    try {
-      const payload = {
-        ...payloadSource,
-        otherIncome: payloadSource.otherIncomeMonthly ?? payloadSource.otherIncome ?? '0',
-        benefitsIncome: payloadSource.benefitsIncomeMonthly ?? payloadSource.benefitsIncome ?? '0',
-      };
+      try {
+        const payload = {
+          ...payloadSource,
+          otherIncome: payloadSource.otherIncomeMonthly ?? payloadSource.otherIncome ?? '0',
+          benefitsIncome: payloadSource.benefitsIncomeMonthly ?? payloadSource.benefitsIncome ?? '0',
+          housingPaymentMonthly: payloadSource.expensesHousing ?? '0',
+        };
       const response = await fetch('/api/generate-report', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Summary
- collect rent or mortgage spending exclusively in the expenses step and add targeted mortgage rate inputs for homeowners
- include housing payments in the submission payload and expand the API’s mortgage calculations for debt service and amortisation reporting
- update review summaries and validation rules to reflect the streamlined questions and new computed mortgage figures

## Testing
- npm run lint *(fails: Cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_690ce7a2012c832085d355aae3730920