### PR TITLE
Fix blueprint survey navigation text and partner retirement validation

### DIFF
--- a/src/pages/financial-blueprint/Step7_Protection.jsx
+++ b/src/pages/financial-blueprint/Step7_Protection.jsx
@@ -225,7 +225,7 @@ const Step7_Protection = ({
           onClick={onNext}
           className="inline-flex justify-center rounded-md border border-transparent bg-indigo-600 py-2 px-4 text-sm font-medium text-white shadow-sm hover:bg-indigo-700"
         >
-          Review answers
+          Continue
         </button>
       </div>
     </div>

--- a/src/pages/financial-blueprint/schemas.js
+++ b/src/pages/financial-blueprint/schemas.js
@@ -390,8 +390,8 @@ export const step8Schema = z
       .max(80, { message: 'Please provide a realistic retirement age.' }),
     partnerRetirementTargetAge: z.coerce
       .number({ required_error: "Partner's target retirement age is required." })
-      .min(50, { message: "Partner's retirement age should be at least 50." })
-      .max(80, { message: 'Please provide a realistic retirement age for your partner.' })
+      .min(0, { message: "Partner's retirement age cannot be negative." })
+      .max(120, { message: 'Please provide a realistic retirement age for your partner.' })
       .optional(),
     retirementIncomeTargetMonthly: moneyField('Desired monthly retirement income'),
     partnerRetirementIncomeTargetMonthly: moneyField(
@@ -426,11 +426,17 @@ export const step8Schema = z
         });
       }
     } else {
-      if (!data.partnerRetirementTargetAge) {
+      if (!data.partnerRetirementTargetAge || data.partnerRetirementTargetAge < 50) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           path: ['partnerRetirementTargetAge'],
-          message: 'Please provide your partner’s target retirement age.',
+          message: 'Please provide your partner’s target retirement age (between 50 and 80).',
+        });
+      } else if (data.partnerRetirementTargetAge > 80) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['partnerRetirementTargetAge'],
+          message: 'Please provide a realistic retirement age for your partner.',
         });
       }
       if (data.partnerRetirementIncomeTargetMonthly <= 0) {


### PR DESCRIPTION
## Summary
- update the protection step CTA label to display Continue to match the other steps
- relax the retirement goals validation so individual blueprints can proceed without partner details

## Testing
- npm run lint *(fails: Cannot find module '@eslint/js')*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918d7278f688320920a58ecb7a57d31)