### PR TITLE
Add export controls and fix action plan currency

### DIFF
--- a/src/pages/financial-blueprint/ReportDisplay.jsx
+++ b/src/pages/financial-blueprint/ReportDisplay.jsx
@@ -18,7 +18,7 @@ const ReportDisplay = ({ reportData }) => {
       </div>
     );
   }
-  
+
   // Destructure the data from the report for easier access
   const {
     profileSummary,
@@ -33,11 +33,61 @@ const ReportDisplay = ({ reportData }) => {
     actionPlan,
   } = reportData;
 
+  const convertReportToCSV = (data) => {
+    if (!data) return '';
+
+    const rows = [['Section', 'Details']];
+
+    Object.entries(data).forEach(([section, value]) => {
+      if (Array.isArray(value)) {
+        value.forEach((item, index) => {
+          rows.push([
+            `${section} ${index + 1}`,
+            typeof item === 'object' && item !== null ? JSON.stringify(item) : item,
+          ]);
+        });
+      } else if (typeof value === 'object' && value !== null) {
+        rows.push([section, JSON.stringify(value)]);
+      } else {
+        rows.push([section, value ?? '']);
+      }
+    });
+
+    return rows
+      .map((row) => row.map((field) => `"${String(field ?? '').replace(/"/g, '""')}"`).join(','))
+      .join('\n');
+  };
+
+  const handlePrint = () => {
+    if (typeof window !== 'undefined') {
+      window.print();
+    }
+  };
+
+  const handleExportCSV = () => {
+    if (typeof window === 'undefined') return;
+
+    const csvContent = convertReportToCSV(reportData);
+    const blob = new window.Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
+    const url = window.URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.setAttribute('download', 'financial-blueprint-report.csv');
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    window.URL.revokeObjectURL(url);
+  };
+
   return (
     <div className="max-w-4xl mx-auto p-4 sm:p-6 md:p-8 bg-gray-50">
       <div className="text-center mb-8">
-        <h1 className="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">Your Financial Blueprint Report</h1>
-        <p className="mt-2 text-lg text-gray-600">A comprehensive analysis of your financial health.</p>
+        <h1 className="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">
+          Your Financial Blueprint Report
+        </h1>
+        <p className="mt-2 text-lg text-gray-600">
+          A comprehensive analysis of your financial health.
+        </p>
       </div>
 
       {/* Main content area for the report cards */}
@@ -46,11 +96,35 @@ const ReportDisplay = ({ reportData }) => {
         <ProfileSummary data={profileSummary} />
         <FinancialOverview data={financialOverview} />
         <QuantitativeAnalysis data={quantitativeAnalysis} />
-        <TaxAndCashflow data={taxAndCashflow || (taxAnalysis || cashFlowAnalysis ? { tax: taxAnalysis, cashflow: cashFlowAnalysis } : null)} />
+        <TaxAndCashflow
+          data={
+            taxAndCashflow ||
+            (taxAnalysis || cashFlowAnalysis
+              ? { tax: taxAnalysis, cashflow: cashFlowAnalysis }
+              : null)
+          }
+        />
         <RetirementSnapshot data={retirementSnapshot} />
         <ProtectionReview data={protectionReview} />
         <SwotAnalysis data={swotAnalysis} />
         <ActionPlan data={actionPlan} />
+      </div>
+
+      <div className="mt-10 flex flex-col gap-4 sm:flex-row sm:justify-center">
+        <button
+          type="button"
+          onClick={handlePrint}
+          className="inline-flex items-center justify-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-semibold text-gray-700 shadow-sm transition hover:bg-gray-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500"
+        >
+          Print / Save as PDF
+        </button>
+        <button
+          type="button"
+          onClick={handleExportCSV}
+          className="inline-flex items-center justify-center rounded-md bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500"
+        >
+          Export to CSV
+        </button>
       </div>
     </div>
   );

--- a/src/pages/financial-blueprint/report-components/ActionPlan.jsx
+++ b/src/pages/financial-blueprint/report-components/ActionPlan.jsx
@@ -13,6 +13,18 @@ const priorityBadgeStyles = {
   Low: 'bg-blue-100 text-blue-800',
 };
 
+const getPotentialSavingContent = (potentialSaving) => {
+  if (typeof potentialSaving === 'number' && Number.isFinite(potentialSaving)) {
+    return `~£${potentialSaving.toLocaleString()}`;
+  }
+
+  if (typeof potentialSaving === 'string') {
+    return potentialSaving.trim();
+  }
+
+  return null;
+};
+
 const ActionPlan = ({ data }) => {
   if (!data || data.length === 0) return null;
 
@@ -20,22 +32,33 @@ const ActionPlan = ({ data }) => {
     <div className="bg-white shadow-md rounded-lg p-6">
       <h2 className="text-xl font-semibold text-gray-800 mb-4">Action Plan: Your Priority Steps</h2>
       <div className="space-y-4">
-        {data.map((item, index) => (
-          <div key={index} className={`p-4 border-l-4 ${priorityStyles[item.priority] || 'border-gray-300'} bg-gray-50 rounded-r-lg`}>
-            <div className="flex justify-between items-center">
-              <h3 className="font-semibold text-gray-900">{item.action}</h3>
-              <span className={`text-xs font-medium px-2.5 py-0.5 rounded-full ${priorityBadgeStyles[item.priority] || 'bg-gray-100 text-gray-800'}`}>
-                {item.priority}
-              </span>
+        {data.map((item, index) => {
+          const potentialSavingContent = getPotentialSavingContent(item.potentialSaving);
+
+          return (
+            <div
+              key={index}
+              className={`p-4 border-l-4 ${priorityStyles[item.priority] || 'border-gray-300'} bg-gray-50 rounded-r-lg`}
+            >
+              <div className="flex justify-between items-center">
+                <h3 className="font-semibold text-gray-900">{item.action}</h3>
+                <span
+                  className={`text-xs font-medium px-2.5 py-0.5 rounded-full ${
+                    priorityBadgeStyles[item.priority] || 'bg-gray-100 text-gray-800'
+                  }`}
+                >
+                  {item.priority}
+                </span>
+              </div>
+              <p className="text-sm text-gray-600 mt-1">{item.explanation}</p>
+              {potentialSavingContent && (
+                <p className="text-sm font-semibold text-green-600 mt-2">
+                  Potential annual saving: {potentialSavingContent}
+                </p>
+              )}
             </div>
-            <p className="text-sm text-gray-600 mt-1">{item.explanation}</p>
-            {item.potentialSaving && (
-              <p className="text-sm font-semibold text-green-600 mt-2">
-                Potential annual saving: ~£{item.potentialSaving.toLocaleString()}
-              </p>
-            )}
-          </div>
-        ))}
+          );
+        })}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add print/PDF and CSV export controls to the financial blueprint report along with CSV serialization helpers
- sanitize action plan potential savings to avoid duplicate currency symbols and support descriptive strings

## Testing
- `npx eslint src/pages/financial-blueprint/ReportDisplay.jsx src/pages/financial-blueprint/report-components/ActionPlan.jsx`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918df27b4848320a831f26aed0d9289)